### PR TITLE
Change height to leaf index in Solidity and tests

### DIFF
--- a/contracts/anchors/bridged/2/AnchorBase2.sol
+++ b/contracts/anchors/bridged/2/AnchorBase2.sol
@@ -28,7 +28,7 @@ abstract contract AnchorBase2 is MerkleTreePoseidon, ReentrancyGuard {
   struct Edge {
     uint256 chainID;
     bytes32 root;
-    uint256 height;
+    uint256 latestLeafIndex;
   }
 
   // maps sourceChainID to the index in the edge list
@@ -54,8 +54,8 @@ abstract contract AnchorBase2 is MerkleTreePoseidon, ReentrancyGuard {
   event Deposit(bytes32 indexed commitment, uint32 leafIndex, uint256 timestamp);
   event Withdrawal(address to, bytes32 nullifierHash, address indexed relayer, uint256 fee);
   // bridge events
-  event EdgeAddition(uint256 chainID, uint256 height, bytes32 merkleRoot);
-  event EdgeUpdate(uint256 chainID, uint256 height, bytes32 merkleRoot);
+  event EdgeAddition(uint256 chainID, uint256 latestLeafIndex, bytes32 merkleRoot);
+  event EdgeUpdate(uint256 chainID, uint256 latestLeafIndex, bytes32 merkleRoot);
   event RootHistoryRecorded(uint timestamp, bytes32[1] roots);
   event RootHistoryUpdate(uint timestamp, bytes32[1] roots);
 

--- a/contracts/handlers/AnchorHandler.sol
+++ b/contracts/handlers/AnchorHandler.sol
@@ -21,7 +21,7 @@ contract AnchorHandler is IExecutor, HandlerHelpers {
         uint256  _sourceChainID;
         bytes32 _resourceID;
         bytes32 _merkleRoot;
-        uint256 _blockHeight;
+        uint256 _leafIndex;
     }
 
     // sourceChainID => height => Update Record
@@ -73,18 +73,18 @@ contract AnchorHandler is IExecutor, HandlerHelpers {
         @notice Proposal execution should be initiated when a proposal is finalized in the Bridge contract.
         by a relayer on the deposit's destination chain.
         @param resourceID ResourceID corresponding to a particular set of Anchors
-        @param data Consists of {sourceChainID}, {blockHeight}, {merkleRoot} all padded to 32 bytes.
+        @param data Consists of {sourceChainID}, {leafIndex}, {merkleRoot} all padded to 32 bytes.
         @notice Data passed into the function should be constructed as follows:
-        chainID                                  uint256       bytes  0 - 32
-        blockHeight                              uint256     bytes  32 - 64
+        chainID                                  uint256     bytes  0 - 32
+        leafIndex                                uint256     bytes  32 - 64
         merkleRoot                               uint256     bytes  64 - 96
      */
     function executeProposal(bytes32 resourceID, bytes calldata data) external override onlyBridge {
         uint256       sourceChainId;
-        uint256       blockHeight;
+        uint256       leafIndex;
         uint256       merkleRoot;
 
-        (sourceChainId, blockHeight, merkleRoot) = abi.decode(data, (uint256, uint, uint));
+        (sourceChainId, leafIndex, merkleRoot) = abi.decode(data, (uint256, uint, uint));
 
         address anchorAddress = _resourceIDToContractAddress[resourceID];
 
@@ -96,13 +96,13 @@ contract AnchorHandler is IExecutor, HandlerHelpers {
             anchor.updateEdge(
                 sourceChainId,
                 bytes32(merkleRoot),
-                blockHeight
+                leafIndex
             );
         } else {
             anchor.addEdge(
                 sourceChainId,
                 bytes32(merkleRoot),
-                blockHeight
+                leafIndex
             );
         }
 
@@ -112,7 +112,7 @@ contract AnchorHandler is IExecutor, HandlerHelpers {
             sourceChainId,
             resourceID,
             bytes32(merkleRoot),
-            blockHeight
+            leafIndex
         );
     }
 }

--- a/contracts/interfaces/ILinkableAnchor.sol
+++ b/contracts/interfaces/ILinkableAnchor.sol
@@ -12,11 +12,11 @@ interface ILinkableAnchor {
   function addEdge(
     uint256 sourceChainID,
     bytes32 root,
-    uint256 height
+    uint256 latestLeafIndex
   ) external payable;
   function updateEdge(
     uint256 sourceChainID,
     bytes32 root,
-    uint256 height
+    uint256 latestLeafIndex
   ) external payable;
 }

--- a/scripts/evm/linkAnchors.ts
+++ b/scripts/evm/linkAnchors.ts
@@ -48,13 +48,13 @@ async function depositAndProposeAndExecute({
   const data = receipt.events[2].args;
   // @ts-ignore
   const updateNonce = data[1];
-  const originBlockHeight = receipt.blockNumber;
+  const originLatestLeafIndex = data.leafIndex;
 
   const originChainID = await originWallet.getChainId();
   const originMerkleRoot = await originAnchor.getLastRoot();
   // create correct update proposal data for the deposit on origin chain
-  const updateData = helpers.createUpdateProposalData(originChainID, originBlockHeight, originMerkleRoot);
-  console.log('Created update data w/ args', originChainID, originBlockHeight, originMerkleRoot, updateData)
+  const updateData = helpers.createUpdateProposalData(originChainID, originLatestLeafIndex, originMerkleRoot);
+  console.log('Created update data w/ args', originChainID, originLatestLeafIndex, originMerkleRoot, updateData)
   const dataHash = ethers.utils.keccak256(destAnchorHandler.address + updateData.substr(2));
   // create destination resourceID to create proposals to update against
   const destChainId = await destWallet.getChainId();

--- a/test/anchor/addEdges.js
+++ b/test/anchor/addEdges.js
@@ -54,14 +54,14 @@ contract('LinkableAnchor - [add edges]', async accounts => {
     addEdge = (edge, sender) => AnchorInstance.addEdge(
       edge.sourceChainID,
       edge.root,
-      edge.height,
+      edge.latestLeafIndex,
       { from: sender }
     )
 
     updateEdge = (edge, sender) => AnchorInstance.updateEdge(
       edge.sourceChainID,
       edge.root,
-      edge.height,
+      edge.latestLeafIndex,
       { from: sender }
     )
   });
@@ -86,7 +86,7 @@ contract('LinkableAnchor - [add edges]', async accounts => {
     const edge = {
       sourceChainID: '0x01',
       root: '0x1111111111111111111111111111111111111111111111111111111111111111',
-      height: 1,
+      latestLeafIndex: 1,
     };
 
     await TruffleAssert.passes(addEdge(edge, accounts[0]));
@@ -101,7 +101,7 @@ contract('LinkableAnchor - [add edges]', async accounts => {
     const edge = {
       sourceChainID: '0x01',
       root: '0x1111111111111111111111111111111111111111111111111111111111111111',
-      height: 1,
+      latestLeafIndex: 1,
     };
 
     await TruffleAssert.passes(addEdge(edge, accounts[0]));
@@ -113,13 +113,13 @@ contract('LinkableAnchor - [add edges]', async accounts => {
     const edge = {
       sourceChainID: '0x01',
       root: '0x1111111111111111111111111111111111111111111111111111111111111111',
-      height: 1,
+      latestLeafIndex: 1,
     };
 
     const edge1 = {
       sourceChainID: '0x02',
       root: '0x1111111111111111111111111111111111111111111111111111111111111111',
-      height: 1,
+      latestLeafIndex: 1,
     };
 
     await TruffleAssert.passes(addEdge(edge, accounts[0]));
@@ -132,7 +132,7 @@ contract('LinkableAnchor - [add edges]', async accounts => {
     const edge = {
       sourceChainID: '0x01',
       root: '0x1111111111111111111111111111111111111111111111111111111111111111',
-      height: 1,
+      latestLeafIndex: 1,
     };
 
     await TruffleAssert.passes(addEdge(edge, accounts[0]));
@@ -146,14 +146,14 @@ contract('LinkableAnchor - [add edges]', async accounts => {
     const edge = {
       sourceChainID: '0x01',
       root: '0x1111111111111111111111111111111111111111111111111111111111111111',
-      height: 1,
+      latestLeafIndex: 1,
     };
 
     const result = await addEdge(edge, accounts[0]);
 
     TruffleAssert.eventEmitted(result, 'EdgeAddition', (ev) => {
       return ev.chainID == parseInt(edge.sourceChainID, 16) &&
-       ev.height == edge.height && ev.merkleRoot == edge.root
+       ev.latestLeafIndex == edge.latestLeafIndex && ev.merkleRoot == edge.root
     });
   });
 
@@ -161,7 +161,7 @@ contract('LinkableAnchor - [add edges]', async accounts => {
     const edge = {
       sourceChainID: '0x01',
       root: '0x1111111111111111111111111111111111111111111111111111111111111111',
-      height: 1,
+      latestLeafIndex: 1,
     };
 
     const result = await addEdge(edge, accounts[0]);

--- a/test/anchor/anchor.js
+++ b/test/anchor/anchor.js
@@ -71,7 +71,7 @@ contract('Anchor2', (accounts) => {
       edge.destChainID,
       edge.destResourceID,
       edge.root,
-      edge.height,
+      edge.latestLeafIndex,
       { from: _sender }
     )
 
@@ -79,7 +79,7 @@ contract('Anchor2', (accounts) => {
       edge.destChainID,
       edge.destResourceID,
       edge.root,
-      edge.height,
+      edge.latestLeafIndex,
       { from: _sender }
     )
 

--- a/test/anchor/updateEdges.js
+++ b/test/anchor/updateEdges.js
@@ -53,14 +53,14 @@ const Token = artifacts.require("ERC20Mock");
     addEdge = (edge, sender) => AnchorInstance.addEdge(
       edge.sourceChainID,
       edge.root,
-      edge.height,
+      edge.latestLeafIndex,
       { from: sender }
     )
 
     updateEdge = (edge, sender) => AnchorInstance.updateEdge(
       edge.sourceChainID,
       edge.root,
-      edge.height,
+      edge.latestLeafIndex,
       { from: sender }
     )
   });
@@ -85,12 +85,12 @@ const Token = artifacts.require("ERC20Mock");
     const edge = {
       sourceChainID: '0x01',
       root: '0x1111111111111111111111111111111111111111111111111111111111111111',
-      height: 100,
+      latestLeafIndex: 100,
     };
     const edgeUpdated = {
       sourceChainID: '0x01',
       root: '0x2222111111111111111111111111111111111111111111111111111111111111',
-      height: 101,
+      latestLeafIndex: 101,
     };
 
     await TruffleAssert.passes(addEdge(edge, accounts[0]));
@@ -102,12 +102,12 @@ const Token = artifacts.require("ERC20Mock");
     const edge = {
       sourceChainID: '0x01',
       root: '0x1111111111111111111111111111111111111111111111111111111111111111',
-      height: 100,
+      latestLeafIndex: 100,
     };
     const edgeUpdated = {
       sourceChainID: '0x02',
       root: '0x2222111111111111111111111111111111111111111111111111111111111111',
-      height: 101,
+      latestLeafIndex: 101,
     };
     await TruffleAssert.passes(addEdge(edge, accounts[0]));
     await TruffleAssert.reverts(updateEdge(edgeUpdated, accounts[0]));
@@ -117,12 +117,12 @@ const Token = artifacts.require("ERC20Mock");
     const edge = {
       sourceChainID: '0x01',
       root: '0x1111111111111111111111111111111111111111111111111111111111111111',
-      height: 100,
+      latestLeafIndex: 100,
     };
     const edgeUpdated = {
     sourceChainID: '0x01',
       root: '0x2222111111111111111111111111111111111111111111111111111111111111',
-      height: 101,
+      latestLeafIndex: 101,
     };
     await TruffleAssert.passes(addEdge(edge, accounts[0]));
 
@@ -141,12 +141,12 @@ const Token = artifacts.require("ERC20Mock");
     const edge = {
       sourceChainID: '0x01',
       root: '0x1111111111111111111111111111111111111111111111111111111111111111',
-      height: 100,
+      latestLeafIndex: 100,
     };
     const edgeUpdated = {
       sourceChainID: '0x01',
       root: '0x2222111111111111111111111111111111111111111111111111111111111111',
-      height: 101,
+      latestLeafIndex: 101,
     };
     await addEdge(edge, accounts[0]);
     const result = await updateEdge(edgeUpdated, accounts[0]);
@@ -160,12 +160,12 @@ const Token = artifacts.require("ERC20Mock");
     const edge = {
       sourceChainID: '0x01',
       root: '0x1111111111111111111111111111111111111111111111111111111111111111',
-      height: 100,
+      latestLeafIndex: 100,
     };
     const edgeUpdated = {
       sourceChainID: '0x01',
       root: '0x2222111111111111111111111111111111111111111111111111111111111111',
-      height: 101,
+      latestLeafIndex: 101,
     };
     await addEdge(edge, accounts[0]);
     const result = await updateEdge(edgeUpdated, accounts[0]);

--- a/test/anchorbridge/cancelUpdateProposal.js
+++ b/test/anchorbridge/cancelUpdateProposal.js
@@ -28,7 +28,6 @@ contract('Bridge - [CancelUpdateProposal with relayerThreshold == 3]', async (ac
   const expectedUpdateNonce = 1;
   const relayerThreshold = 3;
   const merkleTreeHeight = 31;
-  const blockHeight = 1;
   const sender = accounts[5]
   let merkleRoot;
   let AnchorInstance;
@@ -76,7 +75,8 @@ contract('Bridge - [CancelUpdateProposal with relayerThreshold == 3]', async (ac
 
     await token.mint(sender, tokenDenomination);
     await token.increaseAllowance(AnchorInstance.address, 1000000000, {from: sender});
-    await AnchorInstance.deposit('0x1111111111111111111111111111111111111111111111111111111111111111', {from: sender});
+    let { logs } = await AnchorInstance.deposit('0x1111111111111111111111111111111111111111111111111111111111111111', {from: sender});
+    let latestLeafIndex = logs[0].args.leafIndex;
     merkleRoot = await AnchorInstance.getLastRoot();
     
     resourceID = Helpers.createResourceID(AnchorInstance.address, originChainID);
@@ -89,7 +89,7 @@ contract('Bridge - [CancelUpdateProposal with relayerThreshold == 3]', async (ac
       initialContractAddresses,
     );
 
-    data = Helpers.createUpdateProposalData(originChainID, blockHeight, merkleRoot);
+    data = Helpers.createUpdateProposalData(originChainID, latestLeafIndex, merkleRoot);
     dataHash = Ethers.utils.keccak256(DestinationAnchorHandlerInstance.address + data.substr(2));
 
     await Promise.all([

--- a/test/anchorbridge/createUpdateProposal.js
+++ b/test/anchorbridge/createUpdateProposal.js
@@ -27,7 +27,6 @@ contract('Bridge - [create a update proposal (voteProposal) with relayerThreshol
   const relayerThreshold = 1;
   const expectedCreateEventStatus = 1;
   const merkleTreeHeight = 31;
-  const blockHeight = 1;
   const sender = accounts[0]
 
   let merkleRoot;
@@ -72,7 +71,8 @@ contract('Bridge - [create a update proposal (voteProposal) with relayerThreshol
     
     await token.mint(sender, tokenDenomination);
     await token.increaseAllowance(AnchorInstance.address, 1000000000, {from: sender});
-    await AnchorInstance.deposit('0x1111111111111111111111111111111111111111111111111111111111111111', {from: sender});
+    let { logs } = await AnchorInstance.deposit('0x1111111111111111111111111111111111111111111111111111111111111111', {from: sender});
+    let latestLeafIndex = logs[0].args.leafIndex;
     merkleRoot = await AnchorInstance.getLastRoot();
     
     resourceID = Helpers.createResourceID(AnchorInstance.address, originChainID);
@@ -85,7 +85,7 @@ contract('Bridge - [create a update proposal (voteProposal) with relayerThreshol
       initialContractAddresses,
     );
 
-    data = Helpers.createUpdateProposalData(originChainID, blockHeight, merkleRoot);
+    data = Helpers.createUpdateProposalData(originChainID, latestLeafIndex, merkleRoot);
     dataHash = Ethers.utils.keccak256(DestinationAnchorHandlerInstance.address + data.substr(2));
 
     await Promise.all([
@@ -199,7 +199,6 @@ contract('Bridge - [create an update proposal (voteProposal) with relayerThresho
   const relayerThreshold = 2;
   const expectedCreateEventStatus = 1;
   const merkleTreeHeight = 31;
-  const blockHeight = 1;
   const sender = accounts[0]
 
   let merkleRoot;
@@ -244,7 +243,8 @@ contract('Bridge - [create an update proposal (voteProposal) with relayerThresho
 
     await token.mint(sender, tokenDenomination);
     await token.increaseAllowance(AnchorInstance.address, 1000000000, {from: sender});
-    await AnchorInstance.deposit('0x1111111111111111111111111111111111111111111111111111111111111111', {from: sender});
+    let { logs } = await AnchorInstance.deposit('0x1111111111111111111111111111111111111111111111111111111111111111', {from: sender});
+    let latestLeafIndex = logs[0].args.leafIndex;
     merkleRoot = await AnchorInstance.getLastRoot();
     
     resourceID = Helpers.createResourceID(AnchorInstance.address, originChainID);
@@ -257,7 +257,7 @@ contract('Bridge - [create an update proposal (voteProposal) with relayerThresho
       initialContractAddresses,
     );
 
-    data = Helpers.createUpdateProposalData(originChainID, blockHeight, merkleRoot);
+    data = Helpers.createUpdateProposalData(originChainID, latestLeafIndex, merkleRoot);
     dataHash = Ethers.utils.keccak256(DestinationAnchorHandlerInstance.address + data.substr(2));
 
     await Promise.all([

--- a/test/anchorbridge/voteUpdateProposal.js
+++ b/test/anchorbridge/voteUpdateProposal.js
@@ -33,7 +33,6 @@ contract('Bridge - [voteUpdateProposal with relayerThreshold == 3]', async (acco
   const sender = accounts[5]
 
   let merkleRoot;
-  let blockHeight = 1;
   let expectedUpdateNonce = 1;
   let OriginChainAnchorInstance;
   let DestChainAnchorInstance;
@@ -91,7 +90,8 @@ contract('Bridge - [voteUpdateProposal with relayerThreshold == 3]', async (acco
     
     await token.mint(sender, 10 * tokenDenomination);
     await token.increaseAllowance(OriginChainAnchorInstance.address, 1000000000, {from: sender});
-    await OriginChainAnchorInstance.deposit('0x11111', {from: sender});
+    let { logs } = await OriginChainAnchorInstance.deposit('0x11111', {from: sender});
+    let latestLeafIndex = logs[0].args.leafIndex;
     merkleRoot = await OriginChainAnchorInstance.getLastRoot();
     resourceID = Helpers.createResourceID(OriginChainAnchorInstance.address, originChainID);
     initialResourceIDs = [resourceID];
@@ -106,7 +106,7 @@ contract('Bridge - [voteUpdateProposal with relayerThreshold == 3]', async (acco
     await DestChainAnchorInstance.setHandler(DestinationAnchorHandlerInstance.address, {from: sender});
     await DestChainAnchorInstance.setBridge(BridgeInstance.address, {from: sender});
 
-    data = Helpers.createUpdateProposalData(originChainID, blockHeight, merkleRoot);
+    data = Helpers.createUpdateProposalData(originChainID, latestLeafIndex, merkleRoot);
     dataHash = Ethers.utils.keccak256(DestinationAnchorHandlerInstance.address + data.substr(2));
 
     await Promise.all([

--- a/test/helpers/bridge.js
+++ b/test/helpers/bridge.js
@@ -7,6 +7,7 @@ const Ethers = require('ethers');
 const crypto = require('crypto')
 const PoseidonHasher = require('../../lib/Poseidon');
 const utils = require("ffjavascript").utils;
+const { isBN, isBigNumber } = require('web3-utils');
 
 const {
   leBuff2int,
@@ -60,10 +61,14 @@ const createERCDepositData = (tokenAmountOrID, lenRecipientAddress, recipientAdd
     recipientAddress.substr(2);                 // recipientAddress               (?? bytes)
 };
 
-const createUpdateProposalData = (sourceChainID, blockHeight, merkleRoot) => {
+const createUpdateProposalData = (sourceChainID, leafIndex, merkleRoot) => {
+  if (typeof leafIndex === 'object') {
+    leafIndex = leafIndex.toNumber();
+  }
+
   return '0x' +
     toHex(sourceChainID, 32).substr(2) +    // chainID (32 bytes)
-    toHex(blockHeight, 32).substr(2) +      // latest block height of incoming root updates (32 bytes)
+    toHex(leafIndex, 32).substr(2) +        // latest leaf index causing the incoming root updates (32 bytes)
     toHex(merkleRoot, 32).substr(2);        // Updated Merkle Root (32 bytes)
 };
 

--- a/test/integration/compAnchorIntegration.js
+++ b/test/integration/compAnchorIntegration.js
@@ -62,8 +62,6 @@ contract('E2E LinkableCompTokenAnchors - Cross chain withdrawals with gov bravo'
   let MINTER_ROLE;
   let originMerkleRoot;
   let destMerkleRoot;
-  let originBlockHeight = 1;
-  let destBlockHeight = 1;
   let originUpdateNonce;
   let destUpdateNonce;
   let hasher, verifier;
@@ -210,8 +208,8 @@ contract('E2E LinkableCompTokenAnchors - Cross chain withdrawals with gov bravo'
     // revoke anchor permissions
     await originWrapperToken.revokeRole(MINTER_ROLE, OriginChainAnchorInstance.address, {from: sender});
     await originToken.mint(user1, initialTokenMintAmount);
-    await originToken.approve(originWrapperToken.address, initialTokenMintAmount, {from: user1});
-    await TruffleAssert.reverts(OriginChainAnchorInstance.wrap(originToken.address, tokenDenomination, {from: user1}),
+    await originToken.approve(originWrapperToken.address, initialTokenMintAmount, { from: user1 });
+    await TruffleAssert.reverts(OriginChainAnchorInstance.wrap(originToken.address, tokenDenomination, { from: user1 }),
       'ERC20PresetMinterPauser: must have minter role');
   })
 
@@ -222,20 +220,21 @@ contract('E2E LinkableCompTokenAnchors - Cross chain withdrawals with gov bravo'
     *  User1 wraps originToken for originWrapperToken
     */
     await originToken.mint(user1, initialTokenMintAmount);
-    await originToken.approve(originWrapperToken.address, initialTokenMintAmount, {from: user1});
-    await originWrapperToken.approve(OriginChainAnchorInstance.address, initialTokenMintAmount, {from: user1});
-    await OriginChainAnchorInstance.wrap(originToken.address, tokenDenomination, {from: user1});
+    await originToken.approve(originWrapperToken.address, initialTokenMintAmount, { from: user1 });
+    await originWrapperToken.approve(OriginChainAnchorInstance.address, initialTokenMintAmount, { from: user1 });
+    await OriginChainAnchorInstance.wrap(originToken.address, tokenDenomination, { from: user1 });
     /*
     *  User1 deposits on origin chain
     */
     // generate deposit commitment targeting withdrawal on destination chain
     originDeposit = helpers.generateDeposit(destChainID);
     // deposit on origin chain and define nonce
-    let { logs } = await OriginChainAnchorInstance.deposit(helpers.toFixedHex(originDeposit.commitment), {from: user1});
-    originUpdateNonce = logs[0].args.leafIndex;
+    let { logs } = await OriginChainAnchorInstance.deposit(helpers.toFixedHex(originDeposit.commitment), { from: user1 });
+    let latestLeafIndex = logs[0].args.leafIndex;
+    originUpdateNonce = latestLeafIndex;
     originMerkleRoot = await OriginChainAnchorInstance.getLastRoot();
     // create correct update proposal data for the deposit on origin chain
-    originUpdateData = helpers.createUpdateProposalData(originChainID, originBlockHeight, originMerkleRoot);
+    originUpdateData = helpers.createUpdateProposalData(originChainID, latestLeafIndex, originMerkleRoot);
     originUpdateDataHash = Ethers.utils.keccak256(DestAnchorHandlerInstance.address + originUpdateData.substr(2));
     /*
     *  Relayers vote on dest chain
@@ -315,21 +314,22 @@ contract('E2E LinkableCompTokenAnchors - Cross chain withdrawals with gov bravo'
     */
     await originToken.mint(user1, initialTokenMintAmount);
     // approve wrapper to transfer user1's originTokens
-    await originToken.approve(originWrapperToken.address, initialTokenMintAmount, {from: user1});
+    await originToken.approve(originWrapperToken.address, initialTokenMintAmount, { from: user1 });
     // approve anchor for deposit
-    await originWrapperToken.approve(OriginChainAnchorInstance.address, initialTokenMintAmount, {from: user1});
-    await OriginChainAnchorInstance.wrap(originToken.address, tokenDenomination, {from: user1});
+    await originWrapperToken.approve(OriginChainAnchorInstance.address, initialTokenMintAmount, { from: user1 });
+    await OriginChainAnchorInstance.wrap(originToken.address, tokenDenomination, { from: user1 });
     /*
     *  User1 deposits on origin chain
     */
     // generate deposit commitment targeting withdrawal on destination chain
     originDeposit = helpers.generateDeposit(destChainID);
     // deposit on origin chain and define nonce
-    let { logs } = await OriginChainAnchorInstance.deposit(helpers.toFixedHex(originDeposit.commitment), {from: user1});
-    originUpdateNonce = logs[0].args.leafIndex;
+    let { logs } = await OriginChainAnchorInstance.deposit(helpers.toFixedHex(originDeposit.commitment), { from: user1 });
+    let latestLeafIndex = logs[0].args.leafIndex;
+    originUpdateNonce = latestLeafIndex;
     originMerkleRoot = await OriginChainAnchorInstance.getLastRoot();
     // create correct update proposal data for the deposit on origin chain
-    originUpdateData = helpers.createUpdateProposalData(originChainID, originBlockHeight, originMerkleRoot);
+    originUpdateData = helpers.createUpdateProposalData(originChainID, latestLeafIndex, originMerkleRoot);
     originUpdateDataHash = Ethers.utils.keccak256(DestAnchorHandlerInstance.address + originUpdateData.substr(2));
     /*
     *  Relayers vote on dest chain
@@ -426,16 +426,16 @@ contract('E2E LinkableCompTokenAnchors - Cross chain withdrawals with gov bravo'
     */
     await destToken.mint(user2, initialTokenMintAmount);
     // approve tokenwrapper to transfer destTokens from user2
-    await destToken.approve(destWrapperToken.address, initialTokenMintAmount, {from: user2});
+    await destToken.approve(destWrapperToken.address, initialTokenMintAmount, { from: user2 });
     // increase allowance for user1 to burn
-    await destWrapperToken.approve(DestChainAnchorInstance.address, initialTokenMintAmount, {from: user1});
+    await destWrapperToken.approve(DestChainAnchorInstance.address, initialTokenMintAmount, { from: user1 });
     // increase allowance for user2 to deposit on destAnchor
-    await destWrapperToken.approve(DestChainAnchorInstance.address, initialTokenMintAmount, {from: user2});
-    await DestChainAnchorInstance.wrap(destToken.address, tokenDenomination, {from: user2});
+    await destWrapperToken.approve(DestChainAnchorInstance.address, initialTokenMintAmount, { from: user2 });
+    await DestChainAnchorInstance.wrap(destToken.address, tokenDenomination, { from: user2 });
     /*
     *  User1 unwraps destWrapperToken for destToken with new liquidity
     */
-    await DestChainAnchorInstance.unwrap(destToken.address, balanceUser1AfterUnwrap, {from: user1});
+    await DestChainAnchorInstance.unwrap(destToken.address, balanceUser1AfterUnwrap, { from: user1 });
     let balanceUser1AfterUnwrapUnwrap = await destToken.balanceOf(user1);
     assert.strictEqual(balanceUser1AfterUnwrapUnwrap.toString(), balanceUser1AfterUnwrap.toString());
     assert.strictEqual((await destWrapperToken.totalSupply()).toString(), toBN(tokenDenomination).add(feeBN).toString());
@@ -445,11 +445,12 @@ contract('E2E LinkableCompTokenAnchors - Cross chain withdrawals with gov bravo'
     // generate deposit commitment
     destDeposit = helpers.generateDeposit(originChainID);
     // deposit on dest chain and define nonce
-    ({logs} = await DestChainAnchorInstance.deposit(helpers.toFixedHex(destDeposit.commitment), {from: user2}));
-    destUpdateNonce = logs[0].args.leafIndex;
+    ({ logs } = await DestChainAnchorInstance.deposit(helpers.toFixedHex(destDeposit.commitment), { from: user2 }));
+    latestLeafIndex = logs[0].args.leafIndex;
+    destUpdateNonce = latestLeafIndex;
     destMerkleRoot = await DestChainAnchorInstance.getLastRoot();
     // create correct update proposal data for the deposit on dest chain
-    destUpdateData = helpers.createUpdateProposalData(destChainID, destBlockHeight, destMerkleRoot);
+    destUpdateData = helpers.createUpdateProposalData(destChainID, latestLeafIndex, destMerkleRoot);
     destUpdateDataHash = Ethers.utils.keccak256(OriginAnchorHandlerInstance.address + destUpdateData.substr(2));
     /*
     *  relayers vote on origin chain
@@ -545,8 +546,8 @@ contract('E2E LinkableCompTokenAnchors - Cross chain withdrawals with gov bravo'
     *  User2 unwraps originWrapperToken for originToken
     */
     //increase allowance for burn
-    await originWrapperToken.approve(OriginChainAnchorInstance.address, initialTokenMintAmount, {from: user2});
-    await OriginChainAnchorInstance.unwrap(originToken.address, balanceUser2AfterWithdraw, {from: user2});
+    await originWrapperToken.approve(OriginChainAnchorInstance.address, initialTokenMintAmount, { from: user2 });
+    await OriginChainAnchorInstance.unwrap(originToken.address, balanceUser2AfterWithdraw, { from: user2 });
     let balanceUser2AfterUnwrap = await originToken.balanceOf(user2);
     assert.strictEqual(balanceUser2AfterUnwrap.toString(), balanceUser2AfterUnwrap.toString());
     assert.strictEqual((await originWrapperToken.totalSupply()).toString(), feeBN.toString());

--- a/test/integration/mixedBridging.js
+++ b/test/integration/mixedBridging.js
@@ -39,7 +39,6 @@ contract('E2E LinkableAnchors - Cross chain withdrawals', async accounts => {
   const recipient = helpers.getRandomRecipient();
 
   let originMerkleRoot;
-  let originBlockHeight = 1;
   let originUpdateNonce;
   let hasher, verifier;
   let OriginERC20MintableInstance;
@@ -168,10 +167,11 @@ contract('E2E LinkableAnchors - Cross chain withdrawals', async accounts => {
     originDeposit = helpers.generateDeposit(destChainID);
     // deposit on origin chain and define nonce
     let { logs } = await OriginChainAnchorInstance.deposit(helpers.toFixedHex(originDeposit.commitment), {from: sender});
-    originUpdateNonce = logs[0].args.leafIndex;
+    let latestLeafIndex = logs[0].args.leafIndex;
+    originUpdateNonce = latestLeafIndex;
     originMerkleRoot = await OriginChainAnchorInstance.getLastRoot();
     // create correct update proposal data for the deposit on origin chain
-    originUpdateData = helpers.createUpdateProposalData(originChainID, originBlockHeight, originMerkleRoot);
+    originUpdateData = helpers.createUpdateProposalData(originChainID, latestLeafIndex, originMerkleRoot);
     originUpdateDataHash = Ethers.utils.keccak256(DestAnchorHandlerInstance.address + originUpdateData.substr(2));
     /*
     *  Relayers vote on dest chain

--- a/test/integration/simpleWithdrawals.js
+++ b/test/integration/simpleWithdrawals.js
@@ -39,8 +39,6 @@ contract('E2E LinkableAnchors - Cross chain withdrawals', async accounts => {
 
   let originMerkleRoot;
   let destMerkleRoot;
-  let originBlockHeight = 1;
-  let destBlockHeight = 1;
   let originUpdateNonce;
   let destUpdateNonce;
   let hasher, verifier;
@@ -157,10 +155,11 @@ contract('E2E LinkableAnchors - Cross chain withdrawals', async accounts => {
     originDeposit = helpers.generateDeposit(destChainID);
     // deposit on origin chain and define nonce
     let { logs } = await OriginChainAnchorInstance.deposit(helpers.toFixedHex(originDeposit.commitment), {from: sender});
-    originUpdateNonce = logs[0].args.leafIndex;
+    let latestLeafIndex = logs[0].args.leafIndex;
+    originUpdateNonce = latestLeafIndex;
     originMerkleRoot = await OriginChainAnchorInstance.getLastRoot();
     // create correct update proposal data for the deposit on origin chain
-    originUpdateData = helpers.createUpdateProposalData(originChainID, originBlockHeight, originMerkleRoot);
+    originUpdateData = helpers.createUpdateProposalData(originChainID, latestLeafIndex, originMerkleRoot);
     originUpdateDataHash = Ethers.utils.keccak256(DestAnchorHandlerInstance.address + originUpdateData.substr(2));
     /*
     *  Relayers vote on dest chain
@@ -260,11 +259,12 @@ contract('E2E LinkableAnchors - Cross chain withdrawals', async accounts => {
     // generate deposit commitment
     destDeposit = helpers.generateDeposit(originChainID);
     // deposit on dest chain and define nonce
-    ({logs} = await DestChainAnchorInstance.deposit(helpers.toFixedHex(destDeposit.commitment), {from: sender}));
-    destUpdateNonce = logs[0].args.leafIndex;
+    ({ logs } = await DestChainAnchorInstance.deposit(helpers.toFixedHex(destDeposit.commitment), {from: sender}));
+    latestLeafIndex = logs[0].args.leafIndex;
+    destUpdateNonce = latestLeafIndex;
     destMerkleRoot = await DestChainAnchorInstance.getLastRoot();
     // create correct update proposal data for the deposit on dest chain
-    destUpdateData = helpers.createUpdateProposalData(destChainID, destBlockHeight, destMerkleRoot);
+    destUpdateData = helpers.createUpdateProposalData(destChainID, latestLeafIndex, destMerkleRoot);
     destUpdateDataHash = Ethers.utils.keccak256(OriginAnchorHandlerInstance.address + destUpdateData.substr(2));
     /*
     *  relayers vote on origin chain


### PR DESCRIPTION
# Overview
This PR changes a value on every edge from the block height to the latest leaf index processed from that edge.

# Motivation
The motivation is that we can easily see the latest leaf index that a bridged chain _knows_ about before making a withdrawal / zkp generation. That way, we can provide more clarity to the user of whether their note is ready for spending across chains. 