### PR TITLE
Update contract type for IAnchor class

### DIFF
--- a/contracts/anchors/FixedDepositAnchor.sol
+++ b/contracts/anchors/FixedDepositAnchor.sol
@@ -139,8 +139,7 @@ contract FixedDepositAnchor is AnchorBase, IFixedDepositAnchor {
 			);
 		} else {
 			require(!commitments[_extData._refreshCommitment], "The commitment has been submitted");
-			uint32 insertedIndex = _insert(_extData._refreshCommitment);
-			commitments[_extData._refreshCommitment] = true;
+			uint32 insertedIndex = insert(_extData._refreshCommitment);
 			emit Refresh(
 				_extData._refreshCommitment,
 				_proof._nullifierHash,

--- a/contracts/anchors/FixedDepositAnchor.sol
+++ b/contracts/anchors/FixedDepositAnchor.sol
@@ -91,8 +91,8 @@ contract FixedDepositAnchor is AnchorBase, IFixedDepositAnchor {
 	 */
 	function deposit(bytes32 _commitment) override public payable {
 		require(msg.value == 0, "ETH value is supposed to be 0 for ERC20 instance");
-		uint32 insertedIndex = insert(_commitment);
 		IMintableERC20(token).transferFrom(msg.sender, address(this), denomination);
+		uint32 insertedIndex = insert(_commitment);
 		emit Deposit(msg.sender, insertedIndex, _commitment, block.timestamp);
 	}
 
@@ -250,8 +250,8 @@ contract FixedDepositAnchor is AnchorBase, IFixedDepositAnchor {
 			address(this)
 		);
 		// insert a new commitment to the tree
-		uint32 insertedIndex = _insert(_commitment);
-		commitments[_commitment] = true;
+		uint32 insertedIndex = insert(_commitment);
+
 		// emit the deposit event
 		emit Deposit(msg.sender, insertedIndex, _commitment, block.timestamp);
 	}

--- a/packages/interfaces/package.json
+++ b/packages/interfaces/package.json
@@ -9,6 +9,7 @@
     "compile": "tsc -p tsconfig.build.json"
   },
   "dependencies": {
+    "@webb-tools/contracts": "0.1.8",
     "@webb-tools/utils": "^0.1.7"
   },
   "publishConfig": {

--- a/packages/interfaces/src/IAnchor.ts
+++ b/packages/interfaces/src/IAnchor.ts
@@ -1,11 +1,12 @@
 import { IAnchorDeposit, IAnchorDepositInfo } from './anchor';
+import { AnchorBase } from '@webb-tools/contracts';
 import { IMerkleProofData } from './vanchor';
 import { Utxo } from "@webb-tools/utils";
 import { BigNumberish, ethers } from 'ethers';
 
 export interface IAnchor {
   signer: ethers.Signer;
-  contract: ethers.Contract;
+  contract: AnchorBase;
   tree: any;
   // hex string of the connected root
   latestSyncedBlock: number;


### PR DESCRIPTION
It is useful for consumers (i.e. relayer tests) of IAnchor interfaces to call into smart contract functions exposed by AnchorBase.sol.