### PR TITLE
Revert scripts to publish the contracts to npm

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,12 +1,15 @@
 {
   "name": "@webb-tools/contracts",
-  "main": "./typechain/index.ts",
+  "main": "./lib/index.js",
   "license": "GPL-3.0-or-later",
   "author": "Webb Developers <drew@webb.tools>",
   "scripts": {
-    "compile": "yarn run clean && yarn run build:contracts",
+    "compile": "yarn compile:contracts && yarn build:library && yarn copy:declarations",
+    "compile:contracts": "yarn run clean && yarn run build:contracts",
+    "build:library": "tsc -p tsconfig.build.json",
+    "copy:declarations": "copyfiles -f ./typechain/*.d.ts ./lib",
     "build": "exit 0",
-    "clean": "rimraf -rf ./typechain && rimraf -rf ./cache && rimraf -rf ./artifacts",
+    "clean": "rimraf -rf ./lib && rimraf -rf ./typechain && rimraf -rf ./cache && rimraf -rf ./artifacts",
     "test": "npx hardhat test",
     "test:parallel": "npx hardhat test --parallel",
     "build:contracts": "npx hardhat compile",


### PR DESCRIPTION
Revert the script in `package.json` in the `contracts` package to publish the `@webb-tools/contracts` to npm.