### PR TITLE
Custom token config

### DIFF
--- a/packages/anchors/package.json
+++ b/packages/anchors/package.json
@@ -9,8 +9,8 @@
     "compile": "tsc -p tsconfig.build.json"
   },
   "dependencies": {
-    "@webb-tools/contracts": "^0.5.8",
-    "@webb-tools/interfaces": "^0.5.8",
+    "@webb-tools/contracts": "^0.5.11",
+    "@webb-tools/interfaces": "^0.5.11",
     "@webb-tools/sdk-core": "0.1.4-119",
     "@webb-tools/semaphore": "0.0.1-5",
     "@webb-tools/utils": "^0.5.7",
@@ -25,6 +25,6 @@
     "type": "git",
     "url": "git://github.com/webb-tools/protocol-solidity.git"
   },
-  "version": "0.5.10",
+  "version": "0.5.11",
   "gitHead": "e1f3b300b6e004ac5a346dc0458bb1d303969d97"
 }

--- a/packages/bridges/package.json
+++ b/packages/bridges/package.json
@@ -9,11 +9,11 @@
     "compile": "tsc -p tsconfig.build.json"
   },
   "dependencies": {
-    "@webb-tools/anchors": "^0.5.10",
-    "@webb-tools/contracts": "^0.5.8",
-    "@webb-tools/interfaces": "^0.5.8",
+    "@webb-tools/anchors": "^0.5.11",
+    "@webb-tools/contracts": "^0.5.11",
+    "@webb-tools/interfaces": "^0.5.11",
     "@webb-tools/sdk-core": "0.1.4-119",
-    "@webb-tools/tokens": "^0.5.10",
+    "@webb-tools/tokens": "^0.5.11",
     "@webb-tools/utils": "^0.5.7",
     "ethers": "5.7.0"
   },
@@ -25,6 +25,6 @@
     "type": "git",
     "url": "git://github.com/webb-tools/protocol-solidity.git"
   },
-  "version": "0.5.10",
+  "version": "0.5.11",
   "gitHead": "e1f3b300b6e004ac5a346dc0458bb1d303969d97"
 }

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -54,6 +54,6 @@
     "type": "git",
     "url": "git://github.com/webb-tools/protocol-solidity.git"
   },
-  "version": "0.5.8",
+  "version": "0.5.11",
   "gitHead": "e1f3b300b6e004ac5a346dc0458bb1d303969d97"
 }

--- a/packages/evm-test-utils/package.json
+++ b/packages/evm-test-utils/package.json
@@ -9,10 +9,10 @@
     "compile": "tsc -p tsconfig.build.json"
   },
   "dependencies": {
-    "@webb-tools/interfaces": "^0.5.8",
+    "@webb-tools/interfaces": "^0.5.11",
     "@webb-tools/sdk-core": "0.1.4-119",
     "@webb-tools/utils": "^0.5.7",
-    "@webb-tools/vbridge": "^0.5.10",
+    "@webb-tools/vbridge": "^0.5.11",
     "ecpair": "^2.0.1",
     "ethers": "5.7.0",
     "ganache": "7.5.0",
@@ -26,6 +26,6 @@
     "type": "git",
     "url": "git://github.com/webb-tools/protocol-solidity.git"
   },
-  "version": "0.5.10",
+  "version": "0.5.11",
   "gitHead": "e1f3b300b6e004ac5a346dc0458bb1d303969d97"
 }

--- a/packages/interfaces/package.json
+++ b/packages/interfaces/package.json
@@ -9,7 +9,7 @@
     "compile": "tsc -p tsconfig.build.json"
   },
   "dependencies": {
-    "@webb-tools/contracts": "^0.5.8",
+    "@webb-tools/contracts": "^0.5.11",
     "@webb-tools/sdk-core": "0.1.4-119"
   },
   "publishConfig": {
@@ -20,6 +20,6 @@
     "type": "git",
     "url": "git://github.com/webb-tools/protocol-solidity.git"
   },
-  "version": "0.5.8",
+  "version": "0.5.11",
   "gitHead": "e1f3b300b6e004ac5a346dc0458bb1d303969d97"
 }

--- a/packages/protocol-solidity/package.json
+++ b/packages/protocol-solidity/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@webb-tools/protocol-solidity",
   "main": "./lib/index.js",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "license": "GPL-3.0-or-later",
   "author": "Webb Developers <drew@webb.tools>",
   "scripts": {
@@ -10,14 +10,14 @@
     "compile": "tsc -p tsconfig.build.json"
   },
   "dependencies": {
-    "@webb-tools/anchors": "^0.5.10",
-    "@webb-tools/bridges": "^0.5.10",
-    "@webb-tools/contracts": "^0.5.8",
-    "@webb-tools/evm-test-utils": "^0.5.10",
-    "@webb-tools/interfaces": "^0.5.8",
-    "@webb-tools/tokens": "^0.5.10",
+    "@webb-tools/anchors": "^0.5.11",
+    "@webb-tools/bridges": "^0.5.11",
+    "@webb-tools/contracts": "^0.5.11",
+    "@webb-tools/evm-test-utils": "^0.5.11",
+    "@webb-tools/interfaces": "^0.5.11",
+    "@webb-tools/tokens": "^0.5.11",
     "@webb-tools/utils": "^0.5.7",
-    "@webb-tools/vbridge": "^0.5.10"
+    "@webb-tools/vbridge": "^0.5.11"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -9,8 +9,8 @@
     "compile": "tsc -p tsconfig.build.json"
   },
   "dependencies": {
-    "@webb-tools/anchors": "^0.5.10",
-    "@webb-tools/contracts": "^0.5.8",
+    "@webb-tools/anchors": "^0.5.11",
+    "@webb-tools/contracts": "^0.5.11",
     "@webb-tools/sdk-core": "0.1.4-119",
     "@webb-tools/utils": "^0.5.7",
     "ethers": "5.7.0"
@@ -23,6 +23,6 @@
     "type": "git",
     "url": "git://github.com/webb-tools/protocol-solidity.git"
   },
-  "version": "0.5.10",
+  "version": "0.5.11",
   "gitHead": "e1f3b300b6e004ac5a346dc0458bb1d303969d97"
 }

--- a/packages/vbridge/package.json
+++ b/packages/vbridge/package.json
@@ -9,12 +9,12 @@
     "compile": "tsc -p tsconfig.build.json"
   },
   "dependencies": {
-    "@webb-tools/anchors": "^0.5.10",
-    "@webb-tools/bridges": "^0.5.10",
-    "@webb-tools/contracts": "^0.5.8",
-    "@webb-tools/interfaces": "^0.5.8",
+    "@webb-tools/anchors": "^0.5.11",
+    "@webb-tools/bridges": "^0.5.11",
+    "@webb-tools/contracts": "^0.5.11",
+    "@webb-tools/interfaces": "^0.5.11",
     "@webb-tools/sdk-core": "0.1.4-119",
-    "@webb-tools/tokens": "^0.5.10",
+    "@webb-tools/tokens": "^0.5.11",
     "@webb-tools/utils": "^0.5.7",
     "ethers": "5.7.0"
   },
@@ -26,6 +26,6 @@
     "type": "git",
     "url": "git://github.com/webb-tools/protocol-solidity.git"
   },
-  "version": "0.5.10",
+  "version": "0.5.11",
   "gitHead": "e1f3b300b6e004ac5a346dc0458bb1d303969d97"
 }

--- a/packages/vbridge/src/VBridge.ts
+++ b/packages/vbridge/src/VBridge.ts
@@ -18,6 +18,17 @@ export type ExistingAssetInput = {
   asset: Record<number, string[]>;
 };
 
+// Token config to to create new token
+export type TokenConfig = {
+  name: string;
+  symbol: string;
+};
+
+// Default token config
+const defaultTokenConfig: TokenConfig = {
+  name: 'webbWETH',
+  symbol: 'webbWETH',
+};
 // Users define an input for a completely new bridge
 export type VBridgeInput = {
   // The tokens which should be supported after deploying from this bridge input
@@ -28,6 +39,9 @@ export type VBridgeInput = {
 
   // The number of max edges for vanchors, if not provided, maxEdges is derived from passed chainIDs.
   maxEdges?: number;
+
+  // Config to create new tokens
+  tokenConfigs?: Map<number, TokenConfig | undefined>;
 
   // Existing webb tokens can be connected
   webbTokens: Map<number, FungibleTokenWrapper | undefined>;
@@ -179,9 +193,10 @@ export class VBridge {
 
       let tokenInstance: FungibleTokenWrapper;
       if (!vBridgeInput.webbTokens.get(chainID)) {
+        let tokenConfig = vBridgeInput.tokenConfigs?.get(chainID) ?? defaultTokenConfig;
         tokenInstance = await FungibleTokenWrapper.createFungibleTokenWrapper(
-          `webbWETH`,
-          `webbWETH`,
+          tokenConfig.name,
+          tokenConfig.symbol,
           0,
           treasury.contract.address,
           tokenWrapperHandler.contract.address,


### PR DESCRIPTION
## Summary of changes
- created  `TokenConfig` which will contain token configuration to create a new token. This will be passed through bridge input  and will be an optional parameter

```
  // Config to create new tokens
  tokenConfigs?: Map<number, TokenConfig | undefined>;
  
  // if token config is not defined use default token config (webbEth)
  let tokenConfig = vBridgeInput.tokenConfigs?.get(chainID) ?? defaultTokenConfig;

```


### Reference issue to close (if applicable)
- Closes 

-----
### Code Checklist 

- [ ] Tested
- [ ] Documented