### PR TITLE
Update the step value to fetching logs on Mumbai

### DIFF
--- a/packages/anchors/src/VAnchor.ts
+++ b/packages/anchors/src/VAnchor.ts
@@ -768,7 +768,7 @@ export class VAnchor extends WebbBridge implements IVAnchor {
     finalBlock = finalBlock || (await this.contract.provider.getBlockNumber());
     console.log(`Getting notes from chain`);
     // number of blocks to query at a time
-    const step = 1024;
+    const step = 1000;
     console.log(`Fetching notes with steps of ${step} logs/request`);
 
     try {


### PR DESCRIPTION
The Mumbai network allows fetching only `1000` blocks for each request. Currently, we are using `1024` so that the dapp will crash in the step of fetching leaves.