### PR TITLE
chore: auto publishes patch versions of packages

### DIFF
--- a/.changesets/config.json
+++ b/.changesets/config.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "https://unpkg.com/@changesets/config@1.6.0/schema.json",
+    "changelog": "@changesets/cli/changelog",
+    "commit": false,
+    "linked": [],
+    "access": "public",
+    "baseBranch": "main",
+    "updateInternalDependencies": "minor",
+    "ignore": [""],
+    "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+      "onlyUpdatePeerDependentsWhenOutOfRange": true
+    }
+  }

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,0 +1,43 @@
+name: Publish
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    name: Packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+
+      - name: Install Dependencies
+        run: yarn
+
+      - name: Publish to NPM registry
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          # auto publishes PATCH version bump
+          publish: yarn publish:ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Slack Notification
+        if: steps.changesets.outputs.published == 'true'
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_USERNAME: 'Webb-Bot'
+          SLACK_CHANNEL: '#webb-protocol-solidity'
+          SLACK_MESSAGE: 'A new version of ${GITHUB_REPOSITORY} packages was published!'

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "fetch:fixtures": "cd packages/contracts/solidity-fixtures && dvc pull && cd ../../../",
     "prettier": "prettier -c .",
     "publish:packages": "lerna run compile && lerna publish",
+    "publish:ci": "lerna run compile && lerna publish patch --yes --message 'chore: release new versions' ",
     "setup:groth16:vanchor2": "./scripts/bash/groth16/vanchor/phase2_poseidon_vanchor2.sh",
     "setup:groth16:vanchor8": "./scripts/bash/groth16/vanchor/phase2_poseidon_vanchor8.sh",
     "setup:groth16:identity-vanchor2": "./scripts/bash/groth16/identity_vanchor/phase2_identity_vanchor2.sh",


### PR DESCRIPTION
## Summary of changes:
- Workflow job that auto publishes packages to a PATCH version bump on PUSH to `main` 
- Packages that would be published:

```
Changes:
 - @webb-tools/anchors: 0.5.14 => 0.5.15
 - @webb-tools/bridges: 0.5.14 => 0.5.15
 - @webb-tools/contracts: 0.5.14 => 0.5.15
 - @webb-tools/evm-test-utils: 0.5.14 => 0.5.15
 - @webb-tools/interfaces: 0.5.14 => 0.5.15
 - @webb-tools/protocol-solidity: 0.5.14 => 0.5.15
 - @webb-tools/tokens: 0.5.14 => 0.5.15
 - @webb-tools/utils: 0.5.8 => 0.5.9
 - @webb-tools/vbridge: 0.5.14 => 0.5.15
```

