### PR TITLE
chore: use different github token permissions

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -30,7 +30,7 @@ jobs:
           # auto publishes PATCH version bump
           publish: yarn publish:ci
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PA_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Slack Notification


### PR DESCRIPTION
Changes introduced in this pr:

- The publish package job fails currently because of the `main` branch protections. That is, the action does not have permission to push a tag to the repo. I have created a PA GITHUB TOKEN that should have the appropriate permissions to resolve the failure.  