### PR TITLE
Fix Duplication Logs

### DIFF
--- a/packages/anchors/src/VAnchor.ts
+++ b/packages/anchors/src/VAnchor.ts
@@ -297,6 +297,7 @@ export class VAnchor extends WebbBridge implements IVAnchor {
 
     return false;
   }
+
   /**
    * Sets up a VAnchor transaction by generate the necessary inputs to the tx.
    * @param inputs a list of UTXOs that are either inside the tree or are dummy inputs
@@ -580,6 +581,7 @@ export class VAnchor extends WebbBridge implements IVAnchor {
 
     return tokenInstance;
   }
+
   public async setWithLeaves(leaves: string[], syncedBlock?: number): Promise<Boolean> {
     let newTree = new MerkleTree(this.tree.levels, leaves);
     let root = toFixedHex(newTree.root());
@@ -661,8 +663,8 @@ export class VAnchor extends WebbBridge implements IVAnchor {
   async getDepositLeaves(
     startingBlock: number,
     finalBlock: number,
-    abortSignal: AbortSignal,
-    retryPromise: (...args: any[]) => PromiseLike<any> // TODO: Determine the type of this function
+    retryPromise: (...args: any[]) => PromiseLike<any>, // TODO: Determine the type of this function
+    abortSignal?: AbortSignal
   ): Promise<{ lastQueriedBlock: number; newLeaves: string[] }> {
     const filter = this.contract.filters.NewCommitment(null, null, null);
 
@@ -703,7 +705,7 @@ export class VAnchor extends WebbBridge implements IVAnchor {
 
     const newCommitments = events
       .sort((a, b) => a.args.index - b.args.index) // Sort events in chronological order
-      .map((e) => BigNumber.from(e.args.commitment).toHexString());
+      .map((e) => toFixedHex(BigNumber.from(e.args.commitment).toHexString()));
     return {
       lastQueriedBlock: finalBlock,
       newLeaves: newCommitments,
@@ -715,8 +717,8 @@ export class VAnchor extends WebbBridge implements IVAnchor {
     owner: Keypair,
     startingBlock: number,
     finalBlock: number,
-    abortSignal: AbortSignal,
-    retryPromise: (...args: any[]) => PromiseLike<any> // TODO: Determine the type of this function
+    retryPromise: (...args: any[]) => PromiseLike<any>, // TODO: Determine the type of this function
+    abortSignal?: AbortSignal
   ): Promise<Utxo[]> {
     const filter = this.contract.filters.NewCommitment(null, null, null);
     let logs: Array<Log> = []; // Read the stored logs into this variable

--- a/packages/anchors/src/VAnchor.ts
+++ b/packages/anchors/src/VAnchor.ts
@@ -676,11 +676,12 @@ export class VAnchor extends WebbBridge implements IVAnchor {
 
     try {
       for (let i = startingBlock; i <= finalBlock; i += step) {
+        const toBlock = finalBlock - i > step ? i + step - 1 : finalBlock;
         const nextLogs = await retryPromise(
           () => {
             return this.contract.provider.getLogs({
               fromBlock: i,
-              toBlock: finalBlock - i > step ? i + step : finalBlock,
+              toBlock,
               ...filter,
             });
           },
@@ -691,7 +692,7 @@ export class VAnchor extends WebbBridge implements IVAnchor {
 
         logs = [...logs, ...nextLogs];
 
-        console.log(`Getting logs for block range: ${i} through ${i + step}`);
+        console.log(`Getting logs for block range: ${i} through ${toBlock}`);
       }
     } catch (e) {
       console.error(e);
@@ -728,11 +729,12 @@ export class VAnchor extends WebbBridge implements IVAnchor {
 
     try {
       for (let i = startingBlock; i < finalBlock; i += step) {
+        const toBlock = finalBlock - i > step ? i + step - 1 : finalBlock;
         const nextLogs = await retryPromise(
           () => {
             return this.contract.provider.getLogs({
               fromBlock: i,
-              toBlock: finalBlock - i > step ? i + step : finalBlock,
+              toBlock,
               ...filter,
             });
           },
@@ -743,7 +745,7 @@ export class VAnchor extends WebbBridge implements IVAnchor {
 
         logs = [...logs, ...nextLogs];
 
-        console.log(`Getting logs for block range: ${i} through ${i + step}`);
+        console.log(`Getting logs for block range: ${i} through ${toBlock}`);
       }
     } catch (e) {
       console.error(e);

--- a/packages/contracts/test/vanchor/mocks/retryPromiseMock.ts
+++ b/packages/contracts/test/vanchor/mocks/retryPromiseMock.ts
@@ -1,0 +1,5 @@
+export async function retryPromiseMock<T extends () => Promise<any>>(
+  executor: T
+): Promise<ReturnType<T>> {
+  return executor();
+}

--- a/packages/contracts/test/vanchor/vanchor.test.ts
+++ b/packages/contracts/test/vanchor/vanchor.test.ts
@@ -1852,7 +1852,7 @@ describe('VAnchor for 1 max edge', () => {
     });
   });
 
-  describe.only('#getDepositLeaves', () => {
+  describe('#getDepositLeaves', () => {
     const deposit = async () => {
       // Alice deposits into the pool
       const aliceDepositAmount = 1e7;


### PR DESCRIPTION
When we fetch the on-chain logs, we used `i` as the `fromBlock` and `i + step` as the `toBlock`, but in the next iteration we re-use `i + step` as the `fromBlock` (the increment statement `i += step`) so that it can duplicate the log at `i + step` block number.

Thanks @salman01zp for helping debug and resolve this issue.

Closes https://github.com/webb-tools/protocol-solidity/issues/257.