### PR TITLE
feat: Allow for passing a custom nonce for the initial governor

### DIFF
--- a/packages/interfaces/src/bridge/index.ts
+++ b/packages/interfaces/src/bridge/index.ts
@@ -6,7 +6,16 @@ import { IBridgeSide } from '../IBridgeSide';
 export type DeployerConfig = Record<number, ethers.Wallet>;
 
 // Initial Governor config the chainId to the initial governor for that chain
-export type GovernorConfig = Record<number, string>;
+export type GovernorWithNonce = {
+  address: string;
+  nonce: number;
+};
+/**
+ * The governor config is a record of chainId => governor eth address
+ * or chainId => {governor: eth address, nonce: number}, where the nonce is the
+ * nonce of the governor at the time of deployment. Nonce is zero if not specified.
+ **/
+export type GovernorConfig = Record<number, string | GovernorWithNonce>;
 
 export type AnchorIdentifier = {
   anchorSize?: ethers.BigNumberish;

--- a/packages/vbridge/src/VBridge.ts
+++ b/packages/vbridge/src/VBridge.ts
@@ -246,8 +246,11 @@ export class VBridge {
       await VBridge.setPermissions(vBridgeInstance, chainGroupedVAnchors);
       createdVAnchors.push(chainGroupedVAnchors);
 
+      const governorAddress =
+        typeof initialGovernor === 'string' ? initialGovernor : initialGovernor.address;
+      const governorNonce = typeof initialGovernor === 'string' ? 0 : initialGovernor.nonce;
       // Transfer ownership of the bridge to the initialGovernor
-      const tx = await vBridgeInstance.transferOwnership(initialGovernor, 0);
+      const tx = await vBridgeInstance.transferOwnership(governorAddress, governorNonce);
       await tx.wait();
       vBridgeSides.set(chainID, vBridgeInstance);
     }


### PR DESCRIPTION
### Overview

The `deployVariableAnchorBridge` static method assumed that the `initialGovernors` nonce is always Zero, which is not always correct. This PR fixes this by adding a way to specify a custom nonce.

### Changes

- Allow the `GovernorConfig` to be either a `chainId` => `governorAddress` (for backward compatibility) or `chainId` => `{ address, nonce }`
- No breaking changes.

