### PR TITLE
Add tests and batching for signed proposal submission

### DIFF
--- a/packages/contracts/contracts/SignatureBridge.sol
+++ b/packages/contracts/contracts/SignatureBridge.sol
@@ -12,25 +12,36 @@ import "./utils/ProposalNonceTracker.sol";
 import "./interfaces/IExecutor.sol";
 
 /**
-    @title Facilitates proposals execution and resource ID additions/updates
-    @author ChainSafe Systems & Webb Technologies.
+	@title Facilitates proposals execution and resource ID additions/updates
+	@author ChainSafe Systems & Webb Technologies.
  */
 contract SignatureBridge is Governable, ChainIdWithType, ProposalNonceTracker {
 	// resourceID => handler address
 	mapping(bytes32 => address) public _resourceIdToHandlerAddress;
 
 	/**
-        Verifying signature of governor over some datahash
-     */
+		Verifying signature of governor over some data
+	 */
 	modifier signedByGovernor(bytes memory data, bytes memory sig) {
 		require(isSignatureFromGovernor(data, sig), "SignatureBridge: Not valid sig from governor");
 		_;
 	}
 
 	/**
-        Verifying batch signatures from a governor over some datahash
-     */
-	modifier batchSignedByGovernor(bytes[] memory data, bytes[] memory sig) {
+		Verifying signature of governor over some datahash
+	 */
+	modifier signedByGovernorPrehashed(bytes32 hashedData, bytes memory sig) {
+		require(
+			isSignatureFromGovernorPrehashed(hashedData, sig),
+			"SignatureBridge: Not valid sig from governor"
+		);
+		_;
+	}
+
+	/**
+		Verifying many signatures from a governor over some datahash
+	 */
+	modifier manySignedByGovernor(bytes[] memory data, bytes[] memory sig) {
 		require(data.length == sig.length, "SignatureBridge: Data and sig lengths must match");
 		for (uint256 i = 0; i < data.length; i++) {
 			require(
@@ -42,22 +53,22 @@ contract SignatureBridge is Governable, ChainIdWithType, ProposalNonceTracker {
 	}
 
 	/**
-        @notice Initializes SignatureBridge with a governor
-        @param initialGovernor Addresses that should be initially granted the relayer role.
-     */
+		@notice Initializes SignatureBridge with a governor
+		@param initialGovernor Addresses that should be initially granted the relayer role.
+	 */
 	constructor(address initialGovernor, uint32 nonce) Governable(initialGovernor, nonce) {}
 
 	/**
-        @notice Sets a new resource for handler contracts that use the IExecutor interface,
-        and maps the {handlerAddress} to {newResourceID} in {_resourceIdToHandlerAddress}.
-        @notice Only callable by an address that currently has the admin role.
-        @param resourceID Target resource ID of the proposal header.
-        @param functionSig Function signature of the proposal header.
-        @param nonce Nonce of the proposal header.
-        @param newResourceID Secondary resourceID begin mapped to a handler address.
-        @param handlerAddress Address of handler resource will be set for.
-        @param sig The signature from the governor of the encoded set resource proposal.
-     */
+		@notice Sets a new resource for handler contracts that use the IExecutor interface,
+		and maps the {handlerAddress} to {newResourceID} in {_resourceIdToHandlerAddress}.
+		@notice Only callable by an address that currently has the admin role.
+		@param resourceID Target resource ID of the proposal header.
+		@param functionSig Function signature of the proposal header.
+		@param nonce Nonce of the proposal header.
+		@param newResourceID Secondary resourceID begin mapped to a handler address.
+		@param handlerAddress Address of handler resource will be set for.
+		@param sig The signature from the governor of the encoded set resource proposal.
+	 */
 	function adminSetResourceWithSignature(
 		bytes32 resourceID,
 		bytes4 functionSig,
@@ -73,6 +84,119 @@ contract SignatureBridge is Governable, ChainIdWithType, ProposalNonceTracker {
 			sig
 		)
 	{
+		_handleSetResource(resourceID, functionSig, nonce, newResourceID, handlerAddress);
+	}
+
+	/**
+		@notice Sets a batch new resources for handler contracts that use the IExecutor interface,
+		and maps the {handlerAddress} to {newResourceID} in {_resourceIdToHandlerAddress}.
+		@notice Only callable by an address that currently has the admin role.
+		@param resourceID Target resource ID of the proposal header.
+		@param functionSig Function signature of the proposal header.
+		@param nonces Nonces of the proposal headers.
+		@param newResourceIDs Secondary resourceIDs begin mapped to a handler address.
+		@param handlerAddresses Addresses of handler resource will be set for.
+		@param hashedData The encoded data of all proposals to be used for easy checking.
+		@param sig The signature from the governor of the encoded set resource proposal.
+	 */
+	function batchAdminSetResourceWithSignature(
+		bytes32 resourceID,
+		bytes4 functionSig,
+		uint32[] memory nonces,
+		bytes32[] memory newResourceIDs,
+		address[] memory handlerAddresses,
+		bytes32 hashedData,
+		bytes memory sig
+	) external manyIncrementingByOne(nonces) signedByGovernorPrehashed(hashedData, sig) {
+		require(
+			nonces.length == newResourceIDs.length &&
+				newResourceIDs.length == handlerAddresses.length,
+			"SignatureBridge::batchAdminSetResourceWithSignature: Array lengths must match"
+		);
+
+		// Encode the proposals into a concatenated blob and hash to verify against the provided hash.
+		bytes[] memory encodedData = new bytes[](nonces.length);
+		for (uint256 i = 0; i < nonces.length; i++) {
+			encodedData[i] = abi.encodePacked(
+				resourceID,
+				functionSig,
+				nonces[i],
+				newResourceIDs[i],
+				handlerAddresses[i]
+			);
+		}
+		require(
+			keccak256(abi.encode(encodedData)) == hashedData,
+			"SignatureBridge::batchAdminSetResourceWithSignature: Hashed data does not match"
+		);
+
+		for (uint i = 0; i < nonces.length; i++) {
+			_handleSetResource(
+				resourceID,
+				functionSig,
+				nonces[i],
+				newResourceIDs[i],
+				handlerAddresses[i]
+			);
+		}
+	}
+
+	/**
+		@notice Executes a proposal signed by the governor.
+		@param data Data meant for execution by execution handlers.
+	 */
+	function executeProposalWithSignature(
+		bytes calldata data,
+		bytes memory sig
+	) external signedByGovernor(data, sig) {
+		_handleExecuteProposal(data);
+	}
+
+	/**
+		@notice Executes a many of proposals signed by the governor in a single tx.
+		@param data Data meant for execution by execution handlers.
+	 */
+	function executeManyProposalsWithSignature(
+		bytes[] calldata data,
+		bytes[] memory sig
+	) external manySignedByGovernor(data, sig) {
+		for (uint256 i = 0; i < data.length; i++) {
+			_handleExecuteProposal(data[i]);
+		}
+	}
+
+	/**
+		@notice Executes a batch of proposals signed by the governor in a single tx.
+		@param data Data meant for execution by execution handlers.
+	 */
+	function batchExecuteProposalsWithSignature(
+		bytes[] calldata data,
+		bytes memory sig
+	) external signedByGovernor(abi.encode(data), sig) {
+		for (uint256 i = 0; i < data.length; i++) {
+			_handleExecuteProposal(data[i]);
+		}
+	}
+
+	function _handleExecuteProposal(bytes calldata data) internal {
+		// Parse resourceID from the data
+		bytes32 resourceID = bytes32(data[0:32]);
+		require(
+			this.isCorrectExecutionChain(resourceID),
+			"SignatureBridge: Batch Executing on wrong chain"
+		);
+		address handler = _resourceIdToHandlerAddress[resourceID];
+		IExecutor executionHandler = IExecutor(handler);
+		executionHandler.executeProposal(resourceID, data);
+	}
+
+	function _handleSetResource(
+		bytes32 resourceID,
+		bytes4 functionSig,
+		uint32 nonce,
+		bytes32 newResourceID,
+		address handlerAddress
+	) internal {
 		require(
 			this.isCorrectExecutionChain(resourceID),
 			"SignatureBridge::adminSetResourceWithSignature: Executing on wrong chain"
@@ -98,45 +222,5 @@ contract SignatureBridge is Governable, ChainIdWithType, ProposalNonceTracker {
 		IExecutor handler = IExecutor(handlerAddress);
 		address executionContext = address(bytes20(newResourceID << (6 * 8)));
 		handler.setResource(newResourceID, executionContext);
-	}
-
-	/**
-        @notice Executes a proposal signed by the governor.
-        @param data Data meant for execution by execution handlers.
-     */
-	function executeProposalWithSignature(
-		bytes calldata data,
-		bytes memory sig
-	) external signedByGovernor(data, sig) {
-		// Parse resourceID from the data
-		bytes32 resourceID = bytes32(data[0:32]);
-		require(
-			this.isCorrectExecutionChain(resourceID),
-			"SignatureBridge: Executing on wrong chain"
-		);
-		address handler = _resourceIdToHandlerAddress[resourceID];
-		IExecutor executionHandler = IExecutor(handler);
-		executionHandler.executeProposal(resourceID, data);
-	}
-
-	/**
-        @notice Executes a batch of proposals signed by the governor.
-        @param data Data meant for execution by execution handlers.
-     */
-	function batchExecuteProposalWithSignature(
-		bytes[] calldata data,
-		bytes[] memory sig
-	) external batchSignedByGovernor(data, sig) {
-		for (uint256 i = 0; i < data.length; i++) {
-			// Parse resourceID from the data
-			bytes32 resourceID = bytes32(data[i][0:32]);
-			require(
-				this.isCorrectExecutionChain(resourceID),
-				"SignatureBridge: Batch Executing on wrong chain"
-			);
-			address handler = _resourceIdToHandlerAddress[resourceID];
-			IExecutor executionHandler = IExecutor(handler);
-			executionHandler.executeProposal(resourceID, data[i]);
-		}
 	}
 }

--- a/packages/contracts/contracts/test/ProposalHelpers.t.sol
+++ b/packages/contracts/contracts/test/ProposalHelpers.t.sol
@@ -19,6 +19,20 @@ contract ProposalHelpers is ChainIdWithType {
 			bytes32(uint256(uint48(typedChainId)));
 	}
 
+	function buildManyResourceIds(
+		uint8 count,
+		address randomResource,
+		bytes6 typedChainId
+	) public pure returns (bytes32[] memory) {
+		bytes32[] memory resourceIds = new bytes32[](count);
+		for (uint8 i = 0; i < count; i++) {
+			bytes32 randomHash = keccak256(abi.encodePacked(i, randomResource));
+			address resource = address(ripemd160(abi.encodePacked(randomHash)));
+			resourceIds[i] = buildResourceId(resource, typedChainId);
+		}
+		return resourceIds;
+	}
+
 	function buildProposalHeader(
 		bytes32 resourceId,
 		bytes4 functionSig,

--- a/packages/contracts/contracts/test/VAnchorHandler.t.sol
+++ b/packages/contracts/contracts/test/VAnchorHandler.t.sol
@@ -7,6 +7,7 @@ pragma solidity >=0.8.19 <0.9.0;
 import { console2 } from "forge-std/console2.sol";
 import { StdCheats } from "forge-std/StdCheats.sol";
 
+import { VAnchorTree } from "../vanchors/instances/VAnchorTree.sol";
 import { Deployer } from "./Deployer.t.sol";
 
 contract VAnchorHandlerTest is Deployer {
@@ -98,5 +99,95 @@ contract VAnchorHandlerTest is Deployer {
 		bytes32 invalidNewResourceId = this.buildResourceId(newAddress, OTHER_CHAIN_ID);
 		vm.expectRevert(bytes("LinkableAnchor: srcResourceID must be the same"));
 		this.executeAnchorUpdateProposal(invalidNewResourceId, merkleRoot, 2);
+	}
+
+	function test_batchExecuteAnchorUpdateProposals(
+		address[2] memory srcVAnchorsBeingLinked,
+		bytes32[2] memory merkleRoots
+	) public {
+		maxEdges = 2;
+		uint32 merkleTreeLevels = 30;
+		VAnchorTree testVAnchor = new VAnchorTree(
+			verifier,
+			merkleTreeLevels,
+			hasher,
+			address(anchorHandler),
+			address(token),
+			maxEdges
+		);
+		// Initialize the vanchor with a minWithdrawal of 0 and maxDeposit of 100 ether
+		testVAnchor.initialize(0, 100 ether);
+
+		bytes32 testVanchorResourceId = setResource(
+			uint32(bridge.getProposalNonce() + 1),
+			address(testVAnchor),
+			address(anchorHandler)
+		);
+
+		vm.assume(srcVAnchorsBeingLinked[0] != srcVAnchorsBeingLinked[1]);
+		bytes[] memory proposals = new bytes[](2);
+		for (uint i = 1; i <= 2; i++) {
+			bytes6 OTHER_CHAIN_ID = this.buildTypedChainId(CHAIN_TYPE, CHAIN_ID + uint32(i));
+			bytes32 srcResourceId = this.buildResourceId(
+				srcVAnchorsBeingLinked[i - 1],
+				OTHER_CHAIN_ID
+			);
+			bytes memory proposal = this.buildAnchorUpdateProposal(
+				testVanchorResourceId,
+				merkleRoots[i - 1],
+				1,
+				srcResourceId
+			);
+			proposals[i - 1] = proposal;
+		}
+		bytes32 hashedData = keccak256(abi.encode(proposals));
+		(uint8 v, bytes32 r, bytes32 s) = vm.sign(1, hashedData);
+		bytes memory sig = abi.encodePacked(r, s, v);
+		bridge.batchExecuteProposalsWithSignature(proposals, sig);
+	}
+
+	function test_batchExecuteAnchorUpdateProposalsFromSameSrc(
+		address srcVAnchorsBeingLinked,
+		bytes32[10] memory merkleRoots
+	) public {
+		bytes6 OTHER_CHAIN_ID = this.buildTypedChainId(CHAIN_TYPE, CHAIN_ID + 1);
+		bytes32 srcResourceId = this.buildResourceId(srcVAnchorsBeingLinked, OTHER_CHAIN_ID);
+		bytes[] memory proposals = new bytes[](10);
+		for (uint i = 1; i <= 10; i++) {
+			bytes memory proposal = this.buildAnchorUpdateProposal(
+				vanchorResourceId,
+				merkleRoots[i - 1],
+				uint32(i),
+				srcResourceId
+			);
+			proposals[i - 1] = proposal;
+		}
+		bytes32 hashedData = keccak256(abi.encode(proposals));
+		(uint8 v, bytes32 r, bytes32 s) = vm.sign(1, hashedData);
+		bytes memory sig = abi.encodePacked(r, s, v);
+		bridge.batchExecuteProposalsWithSignature(proposals, sig);
+	}
+
+	function test_batchExecuteAnchorUpdateProposalsShouldFailWithInvalidNonces(
+		address srcVAnchorsBeingLinked,
+		bytes32[2] memory merkleRoots
+	) public {
+		bytes6 OTHER_CHAIN_ID = this.buildTypedChainId(CHAIN_TYPE, CHAIN_ID + 1);
+		bytes32 srcResourceId = this.buildResourceId(srcVAnchorsBeingLinked, OTHER_CHAIN_ID);
+		bytes[] memory proposals = new bytes[](2);
+		for (uint i = 1; i <= 2; i++) {
+			bytes memory proposal = this.buildAnchorUpdateProposal(
+				vanchorResourceId,
+				merkleRoots[i - 1],
+				1,
+				srcResourceId
+			);
+			proposals[i - 1] = proposal;
+		}
+		bytes32 hashedData = keccak256(abi.encode(proposals));
+		(uint8 v, bytes32 r, bytes32 s) = vm.sign(1, hashedData);
+		bytes memory sig = abi.encodePacked(r, s, v);
+		vm.expectRevert(bytes("LinkableAnchor: New leaf index must be greater"));
+		bridge.batchExecuteProposalsWithSignature(proposals, sig);
 	}
 }

--- a/packages/contracts/contracts/utils/Governable.sol
+++ b/packages/contracts/contracts/utils/Governable.sol
@@ -17,7 +17,12 @@ contract Governable {
 	// Refresh nonce is for rotating the DKG
 	uint32 public refreshNonce = 0;
 
-	/// Storage values relevant to proposer set update
+	// Last time ownership was transferred to a new governor
+	uint256 public lastGovernorUpdateTime;
+
+	/**
+	 * Storage values relevant to proposer set update
+	 */
 
 	// The proposal nonce
 	uint32 public proposerSetUpdateNonce = 0;
@@ -46,9 +51,6 @@ contract Governable {
 		bytes32[] siblingPathNodes;
 		address proposedGovernor;
 	}
-
-	// Last time ownership was transferred to a new govenror
-	uint256 public lastGovernorUpdateTime;
 
 	event GovernanceOwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 	event RecoveredAddress(address indexed recovered);
@@ -92,6 +94,18 @@ contract Governable {
 		bytes memory sig
 	) public view returns (bool) {
 		bytes32 hashedData = keccak256(data);
+		address signer = ECDSA.recover(hashedData, sig);
+		return signer == governor();
+	}
+
+	/**
+        @notice Returns true if the signature is signed by the current governor.
+        @return bool Whether the signature of the data is signed by the governor
+     */
+	function isSignatureFromGovernorPrehashed(
+		bytes32 hashedData,
+		bytes memory sig
+	) public view returns (bool) {
 		address signer = ECDSA.recover(hashedData, sig);
 		return signer == governor();
 	}

--- a/packages/contracts/contracts/utils/ProposalNonceTracker.sol
+++ b/packages/contracts/contracts/utils/ProposalNonceTracker.sol
@@ -12,6 +12,18 @@ pragma solidity ^0.8.18;
 contract ProposalNonceTracker {
 	uint256 public proposalNonce;
 
+	modifier manyIncrementingByOne(uint32[] memory nonces) {
+		for (uint256 i = 0; i < nonces.length; i++) {
+			require(proposalNonce < nonces[i], "ProposalNonceTracker: Invalid nonce");
+			require(
+				nonces[i] <= proposalNonce + 1,
+				"ProposalNonceTracker: Nonce must not increment more than 1"
+			);
+			proposalNonce = nonces[i];
+		}
+		_;
+	}
+
 	modifier onlyIncrementingByOne(uint nonce) {
 		require(proposalNonce < nonce, "ProposalNonceTracker: Invalid nonce");
 		require(


### PR DESCRIPTION
# Overview
This expands on the capabilities of the `SignatureBridge`. The system can now support
- Submitting 1 signed proposal (data, sig)
- Submitting `n` signed proposals with `n` signatures (data[], sig[])
- Submitting `n` signed proposals with 1 signature (data[], sig)

This can be useful for batch executing proposals.