### PR TITLE
Missing Prop in the `splitTxOptions` Function

### DIFF
--- a/packages/anchors/src/types.ts
+++ b/packages/anchors/src/types.ts
@@ -27,12 +27,24 @@ export interface TransactionStateUpdatePayload {
 
 /**
  * Options to be passed to the `setup` function.
- * Make sure update the `splitTransactionOptions` function if you add a new property here.
+ *
+ * NOTE: MAKE SURE UPDATE THE `splitTransactionOptions` FUNCTION (IN `utils.ts`) IF YOU ADD A NEW PROPERTY HERE.
  */
 export interface TransactionOptions {
-  keypair?: Keypair; // for identityVAnchor
-  treeChainId?: string; // for vanchorForest/IdentityVAnchor
-  externalLeaves?: Uint8Array[]; // for vanchorForest
+  /**
+   * For identityVAnchor
+   */
+  keypair?: Keypair; //
+
+  /**
+   * For vanchorForest/IdentityVAnchor
+   */
+  treeChainId?: string;
+
+  /**
+   * For vanchorForest
+   */
+  externalLeaves?: Uint8Array[];
 
   /**
    * The callback to update the transaction state

--- a/packages/anchors/src/types.ts
+++ b/packages/anchors/src/types.ts
@@ -28,7 +28,7 @@ export interface TransactionStateUpdatePayload {
 /**
  * Options to be passed to the `setup` function.
  *
- * NOTE: MAKE SURE UPDATE THE `splitTransactionOptions` FUNCTION (IN `utils.ts`) IF YOU ADD A NEW PROPERTY HERE.
+ * NOTE: MAKE SURE TO UPDATE THE `splitTransactionOptions` FUNCTION (IN `utils.ts`) IF YOU ADD A NEW PROPERTY HERE.
  */
 export interface TransactionOptions {
   /**

--- a/packages/anchors/src/utils.ts
+++ b/packages/anchors/src/utils.ts
@@ -20,7 +20,10 @@ export function checkNativeAddress(tokenAddress: string): boolean {
 export function splitTransactionOptions<T extends Object>(
   options?: T & TransactionOptions
 ): [T, TransactionOptions] {
-  const { keypair, treeChainId, externalLeaves, ...rest } = options ?? {};
+  const { keypair, treeChainId, externalLeaves, onTransactionState, ...rest } = options ?? {};
 
-  return [rest, { keypair, treeChainId, externalLeaves }] as [T, TransactionOptions];
+  return [rest, { keypair, treeChainId, externalLeaves, onTransactionState }] as [
+    T,
+    TransactionOptions
+  ];
 }


### PR DESCRIPTION
### Summary of changes

- Add missing property when splitting tx options in the `splitTransactionOptions` function after adding a new property
- Add comments to remind devs to add the property to the `splitTransactionOptions` function when adding a new property.