### PR TITLE
Change all doc comments in Solidity to use ///, update Governable with relayable force change.

### DIFF
--- a/packages/contracts/contracts/DeterministicDeployFactory.sol
+++ b/packages/contracts/contracts/DeterministicDeployFactory.sol
@@ -2,6 +2,7 @@
  * Copyright 2021-2023 Webb Technologies
  * SPDX-License-Identifier: MIT OR Apache-2.0
  */
+
 pragma solidity ^0.8.18;
 
 contract DeterministicDeployFactory {
@@ -20,16 +21,14 @@ contract DeterministicDeployFactory {
 		return addr;
 	}
 
-	/**
-		@notice Deploy a fungible token
-		@param bytecode The bytecode of the contract
-		@param _salt The salt for the contract
-		@param _feePercentage The fee percentage for wrapping
-		@param _feeRecipient The recipient for fees from wrapping.
-		@param _handler The address of the handler
-		@param _limit The maximum amount of tokens that can be wrapped
-		@param _isNativeAllowed Whether or not native tokens are allowed to be wrapped
-	 */
+	/// @notice Deploy a fungible token
+	/// @param bytecode The bytecode of the contract
+	/// @param _salt The salt for the contract
+	/// @param _feePercentage The fee percentage for wrapping
+	/// @param _feeRecipient The recipient for fees from wrapping.
+	/// @param _handler The address of the handler
+	/// @param _limit The maximum amount of tokens that can be wrapped
+	/// @param _isNativeAllowed Whether or not native tokens are allowed to be wrapped
 	function deployFungibleToken(
 		bytes memory bytecode,
 		uint _salt,
@@ -54,13 +53,11 @@ contract DeterministicDeployFactory {
 		require(success, string(data));
 	}
 
-	/**
-		@notice Deploy a VAnchor
-		@param bytecode The bytecode of the contract
-		@param _salt The salt for the contract
-		@param _minimalWithdrawalAmount The minimal withdrawal amount
-		@param _maximumDepositAmount The maximum deposit amount
-	 */
+	/// @notice Deploy a VAnchor
+	/// @param bytecode The bytecode of the contract
+	/// @param _salt The salt for the contract
+	/// @param _minimalWithdrawalAmount The minimal withdrawal amount
+	/// @param _maximumDepositAmount The maximum deposit amount
 	function deployVAnchor(
 		bytes memory bytecode,
 		uint _salt,

--- a/packages/contracts/contracts/SignatureBridge.sol
+++ b/packages/contracts/contracts/SignatureBridge.sol
@@ -72,7 +72,7 @@ contract SignatureBridge is Governable, ChainIdWithType, ProposalNonceTracker {
 			sig
 		)
 	{
-		_handleSetResource(resourceID, functionSig, nonce, newResourceID, handlerAddress);
+		_handleSetResource(resourceID, functionSig, newResourceID, handlerAddress);
 	}
 
 	/// @notice Sets a batch new resources for handler contracts that use the IExecutor interface,
@@ -120,7 +120,6 @@ contract SignatureBridge is Governable, ChainIdWithType, ProposalNonceTracker {
 			_handleSetResource(
 				resourceID,
 				functionSig,
-				nonces[i],
 				newResourceIDs[i],
 				handlerAddresses[i]
 			);
@@ -173,7 +172,6 @@ contract SignatureBridge is Governable, ChainIdWithType, ProposalNonceTracker {
 	function _handleSetResource(
 		bytes32 resourceID,
 		bytes4 functionSig,
-		uint32 nonce,
 		bytes32 newResourceID,
 		address handlerAddress
 	) internal {

--- a/packages/contracts/contracts/SignatureBridge.sol
+++ b/packages/contracts/contracts/SignatureBridge.sol
@@ -117,12 +117,7 @@ contract SignatureBridge is Governable, ChainIdWithType, ProposalNonceTracker {
 		);
 
 		for (uint i = 0; i < nonces.length; i++) {
-			_handleSetResource(
-				resourceID,
-				functionSig,
-				newResourceIDs[i],
-				handlerAddresses[i]
-			);
+			_handleSetResource(resourceID, functionSig, newResourceIDs[i], handlerAddresses[i]);
 		}
 	}
 

--- a/packages/contracts/contracts/SignatureBridge.sol
+++ b/packages/contracts/contracts/SignatureBridge.sol
@@ -11,25 +11,19 @@ import "./utils/ChainIdWithType.sol";
 import "./utils/ProposalNonceTracker.sol";
 import "./interfaces/IExecutor.sol";
 
-/**
-	@title Facilitates proposals execution and resource ID additions/updates
-	@author ChainSafe Systems & Webb Technologies.
- */
+/// @title Facilitates proposals execution and resource ID additions/updates
+/// @author ChainSafe Systems & Webb Technologies.
 contract SignatureBridge is Governable, ChainIdWithType, ProposalNonceTracker {
 	// resourceID => handler address
 	mapping(bytes32 => address) public _resourceIdToHandlerAddress;
 
-	/**
-		Verifying signature of governor over some data
-	 */
+	/// @notice Verifying signature of governor over some data
 	modifier signedByGovernor(bytes memory data, bytes memory sig) {
 		require(isSignatureFromGovernor(data, sig), "SignatureBridge: Not valid sig from governor");
 		_;
 	}
 
-	/**
-		Verifying signature of governor over some datahash
-	 */
+	/// @notice Verifying signature of governor over some datahash
 	modifier signedByGovernorPrehashed(bytes32 hashedData, bytes memory sig) {
 		require(
 			isSignatureFromGovernorPrehashed(hashedData, sig),
@@ -38,9 +32,7 @@ contract SignatureBridge is Governable, ChainIdWithType, ProposalNonceTracker {
 		_;
 	}
 
-	/**
-		Verifying many signatures from a governor over some datahash
-	 */
+	/// @notice Verifying many signatures from a governor over some datahash
 	modifier manySignedByGovernor(bytes[] memory data, bytes[] memory sig) {
 		require(data.length == sig.length, "SignatureBridge: Data and sig lengths must match");
 		for (uint256 i = 0; i < data.length; i++) {
@@ -52,23 +44,19 @@ contract SignatureBridge is Governable, ChainIdWithType, ProposalNonceTracker {
 		_;
 	}
 
-	/**
-		@notice Initializes SignatureBridge with a governor
-		@param initialGovernor Addresses that should be initially granted the relayer role.
-	 */
+	/// @notice Initializes SignatureBridge with a governor
+	/// @param initialGovernor Addresses that should be initially granted the relayer role.
 	constructor(address initialGovernor, uint32 nonce) Governable(initialGovernor, nonce) {}
 
-	/**
-		@notice Sets a new resource for handler contracts that use the IExecutor interface,
-		and maps the {handlerAddress} to {newResourceID} in {_resourceIdToHandlerAddress}.
-		@notice Only callable by an address that currently has the admin role.
-		@param resourceID Target resource ID of the proposal header.
-		@param functionSig Function signature of the proposal header.
-		@param nonce Nonce of the proposal header.
-		@param newResourceID Secondary resourceID begin mapped to a handler address.
-		@param handlerAddress Address of handler resource will be set for.
-		@param sig The signature from the governor of the encoded set resource proposal.
-	 */
+	/// @notice Sets a new resource for handler contracts that use the IExecutor interface,
+	/// and maps the {handlerAddress} to {newResourceID} in {_resourceIdToHandlerAddress}.
+	/// @notice Only callable by an address that currently has the admin role.
+	/// @param resourceID Target resource ID of the proposal header.
+	/// @param functionSig Function signature of the proposal header.
+	/// @param nonce Nonce of the proposal header.
+	/// @param newResourceID Secondary resourceID begin mapped to a handler address.
+	/// @param handlerAddress Address of handler resource will be set for.
+	/// @param sig The signature from the governor of the encoded set resource proposal.
 	function adminSetResourceWithSignature(
 		bytes32 resourceID,
 		bytes4 functionSig,
@@ -87,18 +75,16 @@ contract SignatureBridge is Governable, ChainIdWithType, ProposalNonceTracker {
 		_handleSetResource(resourceID, functionSig, nonce, newResourceID, handlerAddress);
 	}
 
-	/**
-		@notice Sets a batch new resources for handler contracts that use the IExecutor interface,
-		and maps the {handlerAddress} to {newResourceID} in {_resourceIdToHandlerAddress}.
-		@notice Only callable by an address that currently has the admin role.
-		@param resourceID Target resource ID of the proposal header.
-		@param functionSig Function signature of the proposal header.
-		@param nonces Nonces of the proposal headers.
-		@param newResourceIDs Secondary resourceIDs begin mapped to a handler address.
-		@param handlerAddresses Addresses of handler resource will be set for.
-		@param hashedData The encoded data of all proposals to be used for easy checking.
-		@param sig The signature from the governor of the encoded set resource proposal.
-	 */
+	/// @notice Sets a batch new resources for handler contracts that use the IExecutor interface,
+	/// and maps the {handlerAddress} to {newResourceID} in {_resourceIdToHandlerAddress}.
+	/// @notice Only callable by an address that currently has the admin role.
+	/// @param resourceID Target resource ID of the proposal header.
+	/// @param functionSig Function signature of the proposal header.
+	/// @param nonces Nonces of the proposal headers.
+	/// @param newResourceIDs Secondary resourceIDs begin mapped to a handler address.
+	/// @param handlerAddresses Addresses of handler resource will be set for.
+	/// @param hashedData The encoded data of all proposals to be used for easy checking.
+	/// @param sig The signature from the governor of the encoded set resource proposal.
 	function batchAdminSetResourceWithSignature(
 		bytes32 resourceID,
 		bytes4 functionSig,
@@ -141,10 +127,8 @@ contract SignatureBridge is Governable, ChainIdWithType, ProposalNonceTracker {
 		}
 	}
 
-	/**
-		@notice Executes a proposal signed by the governor.
-		@param data Data meant for execution by execution handlers.
-	 */
+	/// @notice Executes a proposal signed by the governor.
+	/// @param data Data meant for execution by execution handlers.
 	function executeProposalWithSignature(
 		bytes calldata data,
 		bytes memory sig
@@ -152,10 +136,8 @@ contract SignatureBridge is Governable, ChainIdWithType, ProposalNonceTracker {
 		_handleExecuteProposal(data);
 	}
 
-	/**
-		@notice Executes a many of proposals signed by the governor in a single tx.
-		@param data Data meant for execution by execution handlers.
-	 */
+	/// @notice Executes a many of proposals signed by the governor in a single tx.
+	/// @param data Data meant for execution by execution handlers.
 	function executeManyProposalsWithSignature(
 		bytes[] calldata data,
 		bytes[] memory sig
@@ -165,10 +147,8 @@ contract SignatureBridge is Governable, ChainIdWithType, ProposalNonceTracker {
 		}
 	}
 
-	/**
-		@notice Executes a batch of proposals signed by the governor in a single tx.
-		@param data Data meant for execution by execution handlers.
-	 */
+	/// @notice Executes a batch of proposals signed by the governor in a single tx.
+	/// @param data Data meant for execution by execution handlers.
 	function batchExecuteProposalsWithSignature(
 		bytes[] calldata data,
 		bytes memory sig

--- a/packages/contracts/contracts/Treasury.sol
+++ b/packages/contracts/contracts/Treasury.sol
@@ -11,6 +11,9 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "./interfaces/ITreasury.sol";
 import "./utils/ProposalNonceTracker.sol";
 
+/// @title Treasury contract
+/// @author Webb Technologies.
+/// @notice This contract is used to store funds and recover them.
 contract Treasury is ITreasury, ProposalNonceTracker {
 	using SafeERC20 for IERC20;
 	address treasuryHandler;
@@ -18,12 +21,12 @@ contract Treasury is ITreasury, ProposalNonceTracker {
 	event TreasuryHandlerUpdated(address _handler);
 
 	constructor(address _treasuryHandler) {
-		require(_treasuryHandler != address(0), "Treasury Handler can't be 0");
+		require(_treasuryHandler != address(0), "Treasury: Treasury Handler can't be 0");
 		treasuryHandler = _treasuryHandler;
 	}
 
 	modifier onlyHandler() {
-		require(msg.sender == treasuryHandler, "Function can only be called by treasury handler");
+		require(msg.sender == treasuryHandler, "Treasury: Function can only be called by treasury handler");
 		_;
 	}
 
@@ -33,8 +36,8 @@ contract Treasury is ITreasury, ProposalNonceTracker {
 		uint256 amountToRescue,
 		uint32 nonce
 	) external override onlyHandler onlyIncrementingByOne(nonce) {
-		require(to != address(0), "Cannot send liquidity to zero address");
-		require(tokenAddress != address(this), "Cannot rescue wrapped asset");
+		require(to != address(0), "Treasury: Cannot send liquidity to zero address");
+		require(tokenAddress != address(this), "Treasury: Cannot rescue wrapped asset");
 
 		if (tokenAddress == address(0)) {
 			// Native Ether
@@ -59,7 +62,7 @@ contract Treasury is ITreasury, ProposalNonceTracker {
 		address newHandler,
 		uint32 nonce
 	) external override onlyHandler onlyIncrementingByOne(nonce) {
-		require(newHandler != address(0), "Handler cannot be 0");
+		require(newHandler != address(0), "Treasury: Handler cannot be 0");
 		treasuryHandler = newHandler;
 		emit TreasuryHandlerUpdated(treasuryHandler);
 	}

--- a/packages/contracts/contracts/Treasury.sol
+++ b/packages/contracts/contracts/Treasury.sol
@@ -26,7 +26,10 @@ contract Treasury is ITreasury, ProposalNonceTracker {
 	}
 
 	modifier onlyHandler() {
-		require(msg.sender == treasuryHandler, "Treasury: Function can only be called by treasury handler");
+		require(
+			msg.sender == treasuryHandler,
+			"Treasury: Function can only be called by treasury handler"
+		);
 		_;
 	}
 

--- a/packages/contracts/contracts/handlers/AnchorHandler.sol
+++ b/packages/contracts/contracts/handlers/AnchorHandler.sol
@@ -11,21 +11,17 @@ import "../interfaces/IExecutor.sol";
 import "../interfaces/verifiers/ISetVerifier.sol";
 import "../interfaces/ILinkableAnchor.sol";
 
-/**
-    @title Handles Anchor edge list merkle root updates
-    @author Webb Technologies.
-    @notice This contract is intended to be used with the Bridge contract.
- */
+/// @title Handles Anchor edge list merkle root updates
+/// @author Webb Technologies.
+/// @notice This contract is intended to be used with the Bridge contract.
 contract AnchorHandler is IExecutor, HandlerHelpers {
-	/**
-        @param bridgeAddress Contract address of previously deployed Bridge.
-        @param initialResourceIDs Resource IDs are used to identify a specific contract address.
-        These are the Resource IDs this contract will initially support.
-        @param initialContractAddresses These are the addresses the {initialResourceIDs} will point to, and are the contracts that will be
-        called to perform various deposit calls.
-        @dev {initialResourceIDs} and {initialContractAddresses} must have the same length (one resourceID for every address).
-        Also, these arrays must be ordered in the way that {initialResourceIDs}[0] is the intended resourceID for {initialContractAddresses}[0].
-     */
+	/// @param bridgeAddress Contract address of previously deployed Bridge.
+	/// @param initialResourceIDs Resource IDs are used to identify a specific contract address.
+	/// These are the Resource IDs this contract will initially support.
+	/// @param initialContractAddresses These are the addresses the {initialResourceIDs} will point to, and are the contracts that will be
+	/// called to perform various deposit calls.
+	/// @dev {initialResourceIDs} and {initialContractAddresses} must have the same length (one resourceID for every address).
+	/// Also, these arrays must be ordered in the way that {initialResourceIDs}[0] is the intended resourceID for {initialContractAddresses}[0].
 	constructor(
 		address bridgeAddress,
 		bytes32[] memory initialResourceIDs,
@@ -33,9 +29,9 @@ contract AnchorHandler is IExecutor, HandlerHelpers {
 	) {
 		require(
 			initialResourceIDs.length == initialContractAddresses.length,
-			"initialResourceIDs and initialContractAddresses len mismatch"
+			"AnchorHandler: initialResourceIDs and initialContractAddresses len mismatch"
 		);
-		require(bridgeAddress != address(0), "Bridge Address can't be 0");
+		require(bridgeAddress != address(0), "AnchorHandler: Bridge Address can't be 0");
 		_bridgeAddress = bridgeAddress;
 
 		for (uint256 i = 0; i < initialResourceIDs.length; i++) {
@@ -43,11 +39,10 @@ contract AnchorHandler is IExecutor, HandlerHelpers {
 		}
 	}
 
-	/**
-        @notice Proposal execution should be initiated when a proposal is signed and executed by the `SignatureBridge`
-        @param resourceID ResourceID corresponding to a particular executing anchor contract.
-        @param data Consists of a specific proposal data structure for each finer-grained anchor proposal
-     */
+
+	/// @notice Proposal execution should be initiated when a proposal is signed and executed by the `SignatureBridge`
+	/// @param resourceID ResourceID corresponding to a particular executing anchor contract.
+	/// @param data Consists of a specific proposal data structure for each finer-grained anchor proposal
 	function executeProposal(bytes32 resourceID, bytes calldata data) external override onlyBridge {
 		bytes32 resourceId;
 		bytes4 functionSig;
@@ -59,7 +54,7 @@ contract AnchorHandler is IExecutor, HandlerHelpers {
 
 		address anchorAddress = _resourceIDToContractAddress[resourceID];
 
-		require(_contractWhitelist[anchorAddress], "provided tokenAddress is not whitelisted");
+		require(_contractWhitelist[anchorAddress], "AnchorHandler: provided tokenAddress is not whitelisted");
 
 		if (functionSig == bytes4(keccak256("setHandler(address,uint32)"))) {
 			uint32 nonce = uint32(bytes4(arguments[0:4]));
@@ -93,7 +88,7 @@ contract AnchorHandler is IExecutor, HandlerHelpers {
 				nonce
 			);
 		} else {
-			revert("Invalid function sig");
+			revert("AnchorHandler: Invalid function sig");
 		}
 	}
 }

--- a/packages/contracts/contracts/handlers/AnchorHandler.sol
+++ b/packages/contracts/contracts/handlers/AnchorHandler.sol
@@ -39,7 +39,6 @@ contract AnchorHandler is IExecutor, HandlerHelpers {
 		}
 	}
 
-
 	/// @notice Proposal execution should be initiated when a proposal is signed and executed by the `SignatureBridge`
 	/// @param resourceID ResourceID corresponding to a particular executing anchor contract.
 	/// @param data Consists of a specific proposal data structure for each finer-grained anchor proposal
@@ -54,7 +53,10 @@ contract AnchorHandler is IExecutor, HandlerHelpers {
 
 		address anchorAddress = _resourceIDToContractAddress[resourceID];
 
-		require(_contractWhitelist[anchorAddress], "AnchorHandler: provided tokenAddress is not whitelisted");
+		require(
+			_contractWhitelist[anchorAddress],
+			"AnchorHandler: provided tokenAddress is not whitelisted"
+		);
 
 		if (functionSig == bytes4(keccak256("setHandler(address,uint32)"))) {
 			uint32 nonce = uint32(bytes4(arguments[0:4]));

--- a/packages/contracts/contracts/handlers/HandlerHelpers.sol
+++ b/packages/contracts/contracts/handlers/HandlerHelpers.sol
@@ -7,21 +7,19 @@ pragma solidity ^0.8.18;
 
 import "../interfaces/IExecutor.sol";
 
-/**
-    @title Function used across handler contracts.
-    @author Webb Technologies, adapted from ChainSafe Systems.
-    @notice This contract is intended to be used with the Bridge contract.
- */
+/// @title Function used across handler contracts.
+/// @author Webb Technologies, adapted from ChainSafe Systems.
+/// @notice This contract is intended to be used with the Bridge contract.
 abstract contract HandlerHelpers is IExecutor {
 	address public _bridgeAddress;
 
-	// resourceID => token contract address
+	/// resourceID => token contract address
 	mapping(bytes32 => address) public _resourceIDToContractAddress;
 
-	// Execution contract address => resourceID
+	/// Execution contract address => resourceID
 	mapping(address => bytes32) public _contractAddressToResourceID;
 
-	// Execution contract address => is whitelisted
+	/// Execution contract address => is whitelisted
 	mapping(address => bool) public _contractWhitelist;
 
 	modifier onlyBridge() {
@@ -30,18 +28,16 @@ abstract contract HandlerHelpers is IExecutor {
 	}
 
 	function _onlyBridge() private view {
-		require(msg.sender == _bridgeAddress, "sender must be bridge contract");
+		require(msg.sender == _bridgeAddress, "HandlerHelpers: sender must be bridge contract");
 	}
 
-	/**
-        @notice First verifies {_resourceIDToContractAddress}[{resourceID}] and
-        {_contractAddressToResourceID}[{contractAddress}] are not already set,
-        then sets {_resourceIDToContractAddress} with {contractAddress},
-        {_contractAddressToResourceID} with {resourceID},
-        and {_contractWhitelist} to true for {contractAddress}.
-        @param resourceID ResourceID to be used when executing proposals.
-        @param contractAddress Address of contract to be called when a proposal is signed and submitted for execution.
-     */
+	/// @notice First verifies {_resourceIDToContractAddress}[{resourceID}] and
+	/// {_contractAddressToResourceID}[{contractAddress}] are not already set,
+	/// then sets {_resourceIDToContractAddress} with {contractAddress},
+	/// {_contractAddressToResourceID} with {resourceID},
+	/// and {_contractWhitelist} to true for {contractAddress}.
+	/// @param resourceID ResourceID to be used when executing proposals.
+	/// @param contractAddress Address of contract to be called when a proposal is signed and submitted for execution.
 	function setResource(bytes32 resourceID, address contractAddress) external override onlyBridge {
 		_setResource(resourceID, contractAddress);
 	}
@@ -54,7 +50,7 @@ abstract contract HandlerHelpers is IExecutor {
 	}
 
 	function migrateBridge(address newBridge) external override onlyBridge {
-		require(newBridge != address(0), "Bridge address can't be 0");
+		require(newBridge != address(0), "HandlerHelpers: Bridge address can't be 0");
 		_bridgeAddress = newBridge;
 	}
 }

--- a/packages/contracts/contracts/handlers/TokenWrapperHandler.sol
+++ b/packages/contracts/contracts/handlers/TokenWrapperHandler.sol
@@ -10,21 +10,17 @@ import "./HandlerHelpers.sol";
 import "../interfaces/IExecutor.sol";
 import "../interfaces/tokens/IFungibleTokenWrapper.sol";
 
-/**
-    @title Handles FungibleTokenWrapper fee and token updates
-    @author Webb Technologies.
-    @notice This contract is intended to be used with the Bridge and SignatureBridge contracts.
- */
+/// @title Handles FungibleTokenWrapper fee and token updates
+/// @author Webb Technologies.
+/// @notice This contract is intended to be used with the Bridge and SignatureBridge contracts.
 contract TokenWrapperHandler is IExecutor, HandlerHelpers {
-	/**
-        @param bridgeAddress Contract address of previously deployed Bridge.
-        @param initialResourceIDs Resource IDs are used to identify a specific contract address.
-        These are the Resource IDs this contract will initially support.
-        @param initialContractAddresses These are the addresses the {initialResourceIDs} will point to, and are the contracts that will be
-        called to perform various deposit calls.
-        @dev {initialResourceIDs} and {initialContractAddresses} must have the same length (one resourceID for every address).
-        Also, these arrays must be ordered in the way that {initialResourceIDs}[0] is the intended resourceID for {initialContractAddresses}[0].
-     */
+	/// @param bridgeAddress Contract address of previously deployed Bridge.
+	/// @param initialResourceIDs Resource IDs are used to identify a specific contract address.
+	/// These are the Resource IDs this contract will initially support.
+	/// @param initialContractAddresses These are the addresses the {initialResourceIDs} will point to, and are the contracts that will be
+	/// called to perform various deposit calls.
+	/// @dev {initialResourceIDs} and {initialContractAddresses} must have the same length (one resourceID for every address).
+	/// Also, these arrays must be ordered in the way that {initialResourceIDs}[0] is the intended resourceID for {initialContractAddresses}[0].
 	constructor(
 		address bridgeAddress,
 		bytes32[] memory initialResourceIDs,
@@ -32,10 +28,10 @@ contract TokenWrapperHandler is IExecutor, HandlerHelpers {
 	) {
 		require(
 			initialResourceIDs.length == initialContractAddresses.length,
-			"initialResourceIDs and initialContractAddresses len mismatch"
+			"TokenWrapperHandler: initialResourceIDs and initialContractAddresses len mismatch"
 		);
 
-		require(bridgeAddress != address(0), "Bridge address can't be 0");
+		require(bridgeAddress != address(0), "TokenWrapperHandler: Bridge address can't be 0");
 		_bridgeAddress = bridgeAddress;
 
 		for (uint256 i = 0; i < initialResourceIDs.length; i++) {
@@ -43,12 +39,10 @@ contract TokenWrapperHandler is IExecutor, HandlerHelpers {
 		}
 	}
 
-	/**
-        @notice Proposal execution should be initiated when a proposal is finalized in the Bridge contract.
-        by a relayer on the deposit's destination chain. Or when a valid signature is produced by the DKG in the case of SignatureBridge.
-        @param resourceID ResourceID corresponding to a particular set of FungibleTokenWrapper contracts
-        @param data Consists of a specific proposal data structure for each finer-grained token wrapper proposal
-     */
+	/// @notice Proposal execution should be initiated when a proposal is finalized in the Bridge contract.
+	/// by a relayer on the deposit's destination chain. Or when a valid signature is produced by the DKG in the case of SignatureBridge.
+	/// @param resourceID ResourceID corresponding to a particular set of FungibleTokenWrapper contracts
+	/// @param data Consists of a specific proposal data structure for each finer-grained token wrapper proposal
 	function executeProposal(bytes32 resourceID, bytes calldata data) external override onlyBridge {
 		bytes32 resourceId;
 		bytes4 functionSig;
@@ -78,7 +72,7 @@ contract TokenWrapperHandler is IExecutor, HandlerHelpers {
 			address payable feeRecipient = payable(address(bytes20(arguments[4:24])));
 			fungibleToken.setFeeRecipient(feeRecipient, nonce);
 		} else {
-			revert("Invalid function sig");
+			revert("TokenWrapperHandler: Invalid function sig");
 		}
 	}
 }

--- a/packages/contracts/contracts/handlers/TreasuryHandler.sol
+++ b/packages/contracts/contracts/handlers/TreasuryHandler.sol
@@ -10,21 +10,17 @@ import "./HandlerHelpers.sol";
 import "../interfaces/IExecutor.sol";
 import "../interfaces/ITreasury.sol";
 
-/**
-    @title Handles Treasury rescue tokens proposal
-    @author Webb Technologies.
-    @notice This contract is intended to be used with the Bridge and SignatureBridge contracts.
- */
+/// @title Handles Treasury rescue tokens proposal
+/// @author Webb Technologies.
+/// @notice This contract is intended to be used with the Bridge and SignatureBridge contracts.
 contract TreasuryHandler is IExecutor, HandlerHelpers {
-	/**
-        @param bridgeAddress Contract address of previously deployed Bridge.
-        @param initialResourceIDs Resource IDs are used to identify a specific contract address.
-        These are the Resource IDs this contract will initially support.
-        @param initialContractAddresses These are the addresses the {initialResourceIDs} will point to, and are the contracts that will be
-        called to perform various deposit calls.
-        @dev {initialResourceIDs} and {initialContractAddresses} must have the same length (one resourceID for every address).
-        Also, these arrays must be ordered in the way that {initialResourceIDs}[0] is the intended resourceID for {initialContractAddresses}[0].
-     */
+	/// @param bridgeAddress Contract address of previously deployed Bridge.
+	/// @param initialResourceIDs Resource IDs are used to identify a specific contract address.
+	/// These are the Resource IDs this contract will initially support.
+	/// @param initialContractAddresses These are the addresses the {initialResourceIDs} will point to, and are the contracts that will be
+	/// called to perform various deposit calls.
+	/// @dev {initialResourceIDs} and {initialContractAddresses} must have the same length (one resourceID for every address).
+	/// Also, these arrays must be ordered in the way that {initialResourceIDs}[0] is the intended resourceID for {initialContractAddresses}[0].
 	constructor(
 		address bridgeAddress,
 		bytes32[] memory initialResourceIDs,
@@ -32,10 +28,10 @@ contract TreasuryHandler is IExecutor, HandlerHelpers {
 	) {
 		require(
 			initialResourceIDs.length == initialContractAddresses.length,
-			"initialResourceIDs and initialContractAddresses len mismatch"
+			"TreasuryHandler: initialResourceIDs and initialContractAddresses len mismatch"
 		);
 
-		require(bridgeAddress != address(0), "Bridge Adress can't be 0");
+		require(bridgeAddress != address(0), "TreasuryHandler: Bridge Adress can't be 0");
 		_bridgeAddress = bridgeAddress;
 
 		for (uint256 i = 0; i < initialResourceIDs.length; i++) {
@@ -43,16 +39,14 @@ contract TreasuryHandler is IExecutor, HandlerHelpers {
 		}
 	}
 
-	/**
-        @notice Proposal execution should be initiated when a proposal is finalized in the Bridge contract.
-        by a relayer on the deposit's destination chain. Or when a valid signature is produced by the DKG in the case of SignatureBridge.
-        @param resourceID ResourceID corresponding to a particular set of Treasury contracts
-        @param data passed into the function should be constructed as follows:
-        resourceID: bytes 0-32
-        functionSig: bytes 32-36
-        arguments: bytes 36-
-        First 4 bytes of argument is nonce.  
-     */
+    /// @notice Proposal execution should be initiated when a proposal is finalized in the Bridge contract.
+    /// by a relayer on the deposit's destination chain. Or when a valid signature is produced by the DKG in the case of SignatureBridge.
+    /// @param resourceID ResourceID corresponding to a particular set of Treasury contracts
+    /// @param data passed into the function should be constructed as follows:
+    /// resourceID: bytes 0-32
+    /// functionSig: bytes 32-36
+    /// arguments: bytes 36-
+    /// First 4 bytes of argument is nonce.  
 	function executeProposal(bytes32 resourceID, bytes calldata data) external override onlyBridge {
 		bytes32 resourceId;
 		bytes4 functionSig;
@@ -78,7 +72,7 @@ contract TreasuryHandler is IExecutor, HandlerHelpers {
 			uint256 amountToRescue = uint256(bytes32(arguments[44:76]));
 			treasury.rescueTokens(tokenAddress, to, amountToRescue, nonce);
 		} else {
-			revert("Invalid function sig");
+			revert("TreasuryHandler: Invalid function sig");
 		}
 	}
 }

--- a/packages/contracts/contracts/handlers/TreasuryHandler.sol
+++ b/packages/contracts/contracts/handlers/TreasuryHandler.sol
@@ -39,14 +39,14 @@ contract TreasuryHandler is IExecutor, HandlerHelpers {
 		}
 	}
 
-    /// @notice Proposal execution should be initiated when a proposal is finalized in the Bridge contract.
-    /// by a relayer on the deposit's destination chain. Or when a valid signature is produced by the DKG in the case of SignatureBridge.
-    /// @param resourceID ResourceID corresponding to a particular set of Treasury contracts
-    /// @param data passed into the function should be constructed as follows:
-    /// resourceID: bytes 0-32
-    /// functionSig: bytes 32-36
-    /// arguments: bytes 36-
-    /// First 4 bytes of argument is nonce.  
+	/// @notice Proposal execution should be initiated when a proposal is finalized in the Bridge contract.
+	/// by a relayer on the deposit's destination chain. Or when a valid signature is produced by the DKG in the case of SignatureBridge.
+	/// @param resourceID ResourceID corresponding to a particular set of Treasury contracts
+	/// @param data passed into the function should be constructed as follows:
+	/// resourceID: bytes 0-32
+	/// functionSig: bytes 32-36
+	/// arguments: bytes 36-
+	/// First 4 bytes of argument is nonce.
 	function executeProposal(bytes32 resourceID, bytes calldata data) external override onlyBridge {
 		bytes32 resourceId;
 		bytes4 functionSig;

--- a/packages/contracts/contracts/hashers/IHasher.sol
+++ b/packages/contracts/contracts/hashers/IHasher.sol
@@ -5,9 +5,9 @@
 
 pragma solidity ^0.8.18;
 
-/*
- * Hasher interface for hashing 2 uint256 elements.
- */
+/// @title Hasher interface for hashing 2 uint256 elements.
+/// @author Webb Technologies.
+/// @notice This contract is meant to be used to generalize over different hash functions.
 interface IHasher {
 	function hash3(uint256[3] memory array) external view returns (uint256);
 

--- a/packages/contracts/contracts/hashers/KeccakHasher.sol
+++ b/packages/contracts/contracts/hashers/KeccakHasher.sol
@@ -7,9 +7,9 @@ pragma solidity ^0.8.18;
 
 import "./IHasher.sol";
 
-/*
- * Keccak hash functions for 2 inputs.
- */
+/// @title Keccak hash functions for 2 inputs.
+/// @author Webb Technologies.
+/// @notice This contract is intended to be used with keccak merkle trees.
 contract KeccakHasher is IHasher {
 	function hash3(uint256[3] memory array) public pure override returns (uint256) {
 		return uint256(keccak256(abi.encodePacked(array)));
@@ -92,6 +92,6 @@ contract KeccakHasher is IHasher {
 			return bytes32(0x3878a3ff0eda8bcd772059f6c38939e9b4888d7848b36e8645e3929e0ba2f974);
 		else if (i == 31)
 			return bytes32(0x819bff9ae5cb51403b906d369e5a1bbd8b791c51f7c27d3be41f9271d9434af1);
-		else revert("Index out of bounds");
+		else revert("KeccakHasher: Index out of bounds");
 	}
 }

--- a/packages/contracts/contracts/hashers/KeccakHasher.sol
+++ b/packages/contracts/contracts/hashers/KeccakHasher.sol
@@ -26,7 +26,7 @@ contract KeccakHasher is IHasher {
 		return output;
 	}
 
-	/// @dev provides Zero (Empty) elements for a Poseidon MerkleTree. Up to 32 levels
+	/// @dev provides Zero (Empty) elements for a Keccak MerkleTree. Up to 32 levels
 	function zeros(uint256 i) public pure override returns (bytes32) {
 		if (i == 0)
 			return bytes32(0x2fe54c60d3acabf3343a35b6eba15db4821b340f76e741e2249685ed4899af6c);

--- a/packages/contracts/contracts/hashers/Poseidon.sol
+++ b/packages/contracts/contracts/hashers/Poseidon.sol
@@ -2,8 +2,12 @@
  * Copyright 2021-2023 Webb Technologies
  * SPDX-License-Identifier: MIT OR Apache-2.0
  */
+
 pragma solidity ^0.8.18;
 
+/// @title Poseidon hash functions for 2, 3, 4, 5, and 6 input elements.
+/// @author Webb Technologies.
+/// @notice These contracts are meant to be used in the `PoseidonHasher.sol`
 library PoseidonT2 {
 	function poseidon(uint256[1] memory input) public pure returns (uint256) {}
 }

--- a/packages/contracts/contracts/hashers/PoseidonHasher.sol
+++ b/packages/contracts/contracts/hashers/PoseidonHasher.sol
@@ -9,9 +9,9 @@ import "./IHasher.sol";
 import { PoseidonT2, PoseidonT3, PoseidonT4, PoseidonT5, PoseidonT6 } from "./Poseidon.sol";
 import { SnarkConstants } from "./SnarkConstants.sol";
 
-/*
- * Poseidon hash functions for 2, 4, 5, and 11 input elements.
- */
+/// @title Poseidon hash functions for 2, 4, 5, and 11 input elements.
+/// @author Webb Technologies.
+/// @notice This contract is meant to be used for poseidon merkle trees and other poseidon based hashing.
 contract PoseidonHasher is SnarkConstants, IHasher {
 	function hash1(uint256 value) public pure returns (uint256) {
 		uint256[1] memory input;

--- a/packages/contracts/contracts/hashers/SnarkConstants.sol
+++ b/packages/contracts/contracts/hashers/SnarkConstants.sol
@@ -4,8 +4,11 @@
  */
 pragma solidity ^0.8.18;
 
+/// @title SnarkConstants
+/// @author Webb Technologies.
+/// @notice This contract contains the SNARK scalar field.
 contract SnarkConstants {
-	// The scalar field
+	/// The scalar field
 	uint256 internal constant SNARK_SCALAR_FIELD =
 		21888242871839275222246405745257275088548364400416034343698204186575808495617;
 }

--- a/packages/contracts/contracts/interfaces/IExecutor.sol
+++ b/packages/contracts/contracts/interfaces/IExecutor.sol
@@ -5,27 +5,20 @@
 
 pragma solidity ^0.8.18;
 
-/**
-    @title Interface for handler contracts that support proposal executions.
-    @author Webb Technologies, adapted from ChainSafe Systems.
- */
+/// @title Interface for handler contracts that support proposal executions.
+/// @author Webb Technologies, adapted from ChainSafe Systems.
+/// @notice This contract is meant to be used with the `Bridge` and `Handler` contract.
 interface IExecutor {
-	/**
-        @notice It is intended that proposals are executed by the Bridge contract.
-        @param data Consists of additional data needed for a specific deposit execution.
-     */
+	/// @notice It is intended that proposals are executed by the Bridge contract.
+	/// @param data Consists of additional data needed for a specific deposit execution.
 	function executeProposal(bytes32 resourceID, bytes calldata data) external;
 
-	/**
-        @notice Correlates {resourceID} with {contractAddress}.
-        @param resourceID ResourceID to be used when making deposits.
-        @param contractAddress Address of contract to be called when a deposit is made and a deposited is executed.
-     */
+	/// @notice Correlates {resourceID} with {contractAddress}.
+	/// @param resourceID ResourceID to be used when making deposits.
+	/// @param contractAddress Address of contract to be called when a deposit is made and a deposited is executed.
 	function setResource(bytes32 resourceID, address contractAddress) external;
 
-	/**
-        @notice Migrates the bridge to a new bridge address
-        @param newBridge New bridge address
-     */
+	/// @notice Migrates the bridge to a new bridge address
+	/// @param newBridge New bridge address
 	function migrateBridge(address newBridge) external;
 }

--- a/packages/contracts/contracts/interfaces/ILinkableAnchor.sol
+++ b/packages/contracts/contracts/interfaces/ILinkableAnchor.sol
@@ -5,45 +5,35 @@
 
 pragma solidity ^0.8.18;
 
-/**
-    @title ILinkableAnchor Interface
-    @notice The interface supports updating edges for a graph-like functionality.
-    It also supports setting handlers and verifiers for handling updates
-    to the edge data of a LinkableAnchor as well as the verifier used in
-    verifying proofs of knowledge of leaves in one-of-many merkle trees.
-
-    The ILinkableAnchor interface can also be used with the VAnchor system
-    to control the minimal and maximum withdrawal and deposit limits respectively.
- */
+/// @title ILinkableAnchor Interface
+/// @author Webb Technologies.
+/// @notice The interface supports updating edges for a graph-like functionality.
+/// It also supports setting handlers and verifiers for handling updates
+/// to the edge data of a LinkableAnchor as well as the verifier used in
+/// verifying proofs of knowledge of leaves in one-of-many merkle trees.
+/// @notice The ILinkableAnchor interface can also be used with the VAnchor system
+/// to control the minimal and maximum withdrawal and deposit limits respectively.
 interface ILinkableAnchor {
-	/**
-        @notice Sets the handler for updating edges and other contract state
-        @param handler The new handler address
-        @param nonce The nonce for tracking update counts
-     */
+	/// @notice Sets the handler for updating edges and other contract state
+	/// @param handler The new handler address
+	/// @param nonce The nonce for tracking update counts
 	function setHandler(address handler, uint32 nonce) external;
 
-	/**
-        @notice Sets the minimal withdrawal limit for the anchor
-        @param minimalWithdrawalAmount The new minimal withdrawal limit
-     */
+	/// @notice Sets the minimal withdrawal limit for the anchor
+	/// @param minimalWithdrawalAmount The new minimal withdrawal limit
 	function configureMinimalWithdrawalLimit(
 		uint256 minimalWithdrawalAmount,
 		uint32 nonce
 	) external;
 
-	/**
-        @notice Sets the maximal deposit limit for the anchor
-        @param maximumDepositAmount The new maximal deposit limit
-     */
+	/// @notice Sets the maximal deposit limit for the anchor
+	/// @param maximumDepositAmount The new maximal deposit limit
 	function configureMaximumDepositLimit(uint256 maximumDepositAmount, uint32 nonce) external;
 
-	/**
-        @notice The function is used to update the edge data of a LinkableAnchor
-        @param root The merkle root of the linked anchor on the  `sourceChainID`'s chain
-        @param latestLeafIndex The index of the leaf updating the merkle tree with root `root`
-        @param srcResourceID The source resource ID of the linked anchor where the update originates from
-     */
+	/// @notice The function is used to update the edge data of a LinkableAnchor
+	/// @param root The merkle root of the linked anchor on the  `sourceChainID`'s chain
+	/// @param latestLeafIndex The index of the leaf updating the merkle tree with root `root`
+	/// @param srcResourceID The source resource ID of the linked anchor where the update originates from
 	function updateEdge(
 		uint256 root,
 		uint32 latestLeafIndex,

--- a/packages/contracts/contracts/interfaces/IMerkleSystem.sol
+++ b/packages/contracts/contracts/interfaces/IMerkleSystem.sol
@@ -8,30 +8,32 @@ pragma solidity ^0.8.18;
 import "../utils/Initialized.sol";
 import "../hashers/IHasher.sol";
 
-/**
-    @title IMerkleSystem contract for merkle tree like data structures.
-    @author Webb Technologies
- */
+/// @title IMerkleSystem contract for merkle tree like data structures.
+/// @author Webb Technologies.
+/// @notice This contract is meant to be used with the `trees` contracts.
 interface IMerkleSystem {
-	/** @dev Whether the root is present in the root history of the system */
+	/// @dev Whether the root is present in the root history of the system
 	function isKnownRoot(uint256 root) external view returns (bool);
 
-	/** @dev Gets the zero hash for a specific index */
+	/// @dev Gets the zero hash for a specific index
 	function getZeroHash(uint32 index) external view returns (uint256);
 
-	/** @dev Gets the levels of the outer-most merkle tree in the system */
+	/// @dev Gets the levels of the outer-most merkle tree in the system
 	function getLevels() external view returns (uint32);
 
-	/** @dev Gets the last merkle root of the merkle system */
+	/// @dev Gets the last merkle root of the merkle system
 	function getLastRoot() external view returns (uint256);
 
-	/** @dev Gets the next index of a subtree */
+	/// @dev Gets the next index of a subtree
 	function getNextIndex() external view returns (uint32);
 
-	/** @dev Gets the hasher for this merkle system */
+	/// @dev Gets the hasher for this merkle system
 	function getHasher() external view returns (IHasher);
 }
 
+/// @title MerkleSystem contract for merkle tree like data structures.
+/// @author Webb Technologies.
+/// @notice This contract is meant to be used with the `trees` contracts.
 abstract contract MerkleSystem is IMerkleSystem, Initialized {
 	uint256 public constant FIELD_SIZE =
 		21888242871839275222246405745257275088548364400416034343698204186575808495617;
@@ -39,20 +41,20 @@ abstract contract MerkleSystem is IMerkleSystem, Initialized {
 		21663839004416932945382355908790599225266501822907911457504978515578255421292; // = keccak256("tornado") % FIELD_SIZE
 	uint32 public constant ROOT_HISTORY_SIZE = 30;
 
-	// The `Root` struct is used to store the root and the index of
-	// the leaf triggering this root update.
+	/// The `Root` struct is used to store the root and the index of
+	/// the leaf triggering this root update.
 	struct Root {
 		uint256 root;
 		uint32 latestLeafindex;
 	}
 
-	// The mapping of root indices to roots for storing a history of ROOT_HISTORY_SIZE updates
+	/// The mapping of root indices to roots for storing a history of ROOT_HISTORY_SIZE updates
 	mapping(uint256 => Root) public roots;
-	// The mapping of filled subtree indices to filled subtree roots
+	/// The mapping of filled subtree indices to filled subtree roots
 	mapping(uint256 => uint256) public filledSubtrees;
-	// The mapping to store used nullifier hashes / spent commitments
+	/// The mapping to store used nullifier hashes / spent commitments
 	mapping(uint256 => bool) public nullifierHashes;
-	// The mapping to store all commitments to prevent accidental deposits with the same commitment
+	/// The mapping to store all commitments to prevent accidental deposits with the same commitment
 	mapping(uint256 => bool) public commitments;
 
 	event Insertion(
@@ -62,12 +64,12 @@ abstract contract MerkleSystem is IMerkleSystem, Initialized {
 		uint256 indexed newMerkleRoot
 	);
 
-	// Internal functions
+	/// Internal functions
 	function _initialize() internal {
 		initialized = true;
 	}
 
-	/** @dev this function is defined in a child contract */
+	/// @dev this function is defined in a child contract
 	function hashLeftRight(uint256 _left, uint256 _right) public view virtual returns (uint256) {
 		IHasher hasher = this.getHasher();
 		return hasher.hashLeftRight(_left, _right);

--- a/packages/contracts/contracts/interfaces/ITreasury.sol
+++ b/packages/contracts/contracts/interfaces/ITreasury.sol
@@ -5,18 +5,14 @@
 
 pragma solidity ^0.8.18;
 
-/**
-        @title Interface for Treasury contract.
-        @author Webb Technologies.
- */
+/// @title Interface for Treasury contract.
+/// @author Webb Technologies.
 interface ITreasury {
-	/**
-        @notice Sends an `_amountToRescue` of tokens at `_tokenAddress` from the treasury contract to `_to`
-        @param _tokenAddress Address of the token to rescue.
-        @param _to Address of the recipient.
-        @param _amountToRescue Amount of tokens to rescue.
-        @param _nonce Nonce of the rescue transaction.
-     */
+	/// @notice Sends an `_amountToRescue` of tokens at `_tokenAddress` from the treasury contract to `_to`
+	/// @param _tokenAddress Address of the token to rescue.
+	/// @param _to Address of the recipient.
+	/// @param _amountToRescue Amount of tokens to rescue.
+	/// @param _nonce Nonce of the rescue transaction.
 	function rescueTokens(
 		address _tokenAddress,
 		address payable _to,
@@ -24,10 +20,8 @@ interface ITreasury {
 		uint32 _nonce
 	) external;
 
-	/**
-        @notice Sets the handler responsible with relaying rescue transactions.
-        @param _newHandler Address of the handler.
-        @param _nonce Nonce of the update.
-     */
+	/// @notice Sets the handler responsible with relaying rescue transactions.
+	/// @param _newHandler Address of the handler.
+	/// @param _nonce Nonce of the update.
 	function setHandler(address _newHandler, uint32 _nonce) external;
 }

--- a/packages/contracts/contracts/interfaces/external/aave/IAaveLendingPool.sol
+++ b/packages/contracts/contracts/interfaces/external/aave/IAaveLendingPool.sol
@@ -5,6 +5,9 @@
 
 pragma solidity ^0.8.18;
 
+/// @title Lending pool deposit/withdraw functionality for Aave
+/// @author Webb Technologies.
+/// @notice This contract is meant to be used with the `TokenWrapper.sol`.
 interface IAaveLendingPool {
 	function deposit(
 		address asset,

--- a/packages/contracts/contracts/interfaces/external/chainalysis/ISanctionsList.sol
+++ b/packages/contracts/contracts/interfaces/external/chainalysis/ISanctionsList.sol
@@ -5,6 +5,9 @@
 
 pragma solidity ^0.8.18;
 
+/// @title SanctionsList interface for Chainalysis Sanctions List
+/// @author Chainalysis
+/// @notice This contract is meant to be used to check if an address is sanctioned.
 interface ISanctionsList {
 	function isSanctioned(address addr) external view returns (bool);
 }

--- a/packages/contracts/contracts/interfaces/tokens/IAaveTokenWrapper.sol
+++ b/packages/contracts/contracts/interfaces/tokens/IAaveTokenWrapper.sol
@@ -5,22 +5,17 @@
 
 pragma solidity ^0.8.18;
 
-/**
-    @title Interface for Aave Token Wrapper contract.
-    @author Webb Technologies.
- */
+/// @title Interface for Aave Token Wrapper contract.
+/// @author Webb Technologies.
+/// @notice This contract is meant to be used with the `TokenWrapper` contract.
 interface IAaveTokenWrapper {
-	/**
-        @notice Deposits token at `_tokenAddress` into Aave Lending Pool
-        @param _tokenAddress The address of the token to deposit
-        @param _amount The amount to deposit
-     */
+	/// @notice Deposits token at `_tokenAddress` into Aave Lending Pool
+	/// @param _tokenAddress The address of the token to deposit
+	/// @param _amount The amount to deposit
 	function deposit(address _tokenAddress, uint256 _amount) external;
 
-	/**
-        @notice Withdraws token at `_tokenAddress` from Aave Lending Pool
-        @param _tokenAddress The address of the token to withdraw
-        @param _amount The amount to withdraw
-     */
+	/// @notice Withdraws token at `_tokenAddress` from Aave Lending Pool
+	/// @param _tokenAddress The address of the token to withdraw
+	/// @param _amount The amount to withdraw
 	function withdraw(address _tokenAddress, uint256 _amount) external;
 }

--- a/packages/contracts/contracts/interfaces/tokens/IFungibleTokenWrapper.sol
+++ b/packages/contracts/contracts/interfaces/tokens/IFungibleTokenWrapper.sol
@@ -5,40 +5,31 @@
 
 pragma solidity ^0.8.18;
 
-/**
-    @title Interface for Token Wrapper contract.
-    @author Webb Technologies.
- */
+/// @title Interface for Token Wrapper contract.
+/// @author Webb Technologies.
+/// @notice This contract is meant to be used with the `TokenWrapper` contract.
 interface IFungibleTokenWrapper {
-	/**
-        @notice Adds a token at `_tokenAddress` to the FungibleTokenWrapper's wrapping list
-        @param _tokenAddress The address of the token to be added
-        @param _nonce The nonce tracking updates to this contract
-        @notice Only the governor can call this function
-     */
+	/// @notice Adds a token at `_tokenAddress` to the FungibleTokenWrapper's wrapping list
+	/// @param _tokenAddress The address of the token to be added
+	/// @param _nonce The nonce tracking updates to this contract
+	/// @notice Only the governor can call this function
 	function add(address _tokenAddress, uint32 _nonce) external;
 
-	/**
-        @notice Removes a token at `_tokenAddress` from the FungibleTokenWrapper's wrapping list
-        @param _tokenAddress The address of the token to be removed
-        @param _nonce The nonce tracking updates to this contract
-        @notice Only the governor can call this function
-     */
+	/// @notice Removes a token at `_tokenAddress` from the FungibleTokenWrapper's wrapping list
+	/// @param _tokenAddress The address of the token to be removed
+	/// @param _nonce The nonce tracking updates to this contract
+	/// @notice Only the governor can call this function
 	function remove(address _tokenAddress, uint32 _nonce) external;
 
-	/**
-        @notice Sets a new `_feePercentage` for the FungibleTokenWrapper
-        @param _feePercentage The new fee percentage
-        @param _nonce The nonce tracking updates to this contract
-        @notice Only the governor can call this function
-     */
+	/// @notice Sets a new `_feePercentage` for the FungibleTokenWrapper
+	/// @param _feePercentage The new fee percentage
+	/// @param _nonce The nonce tracking updates to this contract
+	/// @notice Only the governor can call this function
 	function setFee(uint16 _feePercentage, uint32 _nonce) external;
 
-	/**
-        @notice Sets a new `_feeRecipient` for the FungibleTokenWrapper
-        @param _feeRecipient The new fee recipient
-        @param _nonce The nonce tracking updates to this contract
-        @notice Only the governor can call this function
-     */
+	/// @notice Sets a new `_feeRecipient` for the FungibleTokenWrapper
+	/// @param _feeRecipient The new fee recipient
+	/// @param _nonce The nonce tracking updates to this contract
+	/// @notice Only the governor can call this function
 	function setFeeRecipient(address payable _feeRecipient, uint32 _nonce) external;
 }

--- a/packages/contracts/contracts/interfaces/tokens/IMintableERC20.sol
+++ b/packages/contracts/contracts/interfaces/tokens/IMintableERC20.sol
@@ -5,35 +5,21 @@
 
 pragma solidity ^0.8.18;
 
-/**
- * @dev Interface of the ERC20 standard as defined in the EIP.
- */
+/// @title Interface for a mintable ERC20 token contract.
+/// @author Webb Technologies.
 interface IMintableERC20 {
-	/**
-	 * @dev Mints `amount` tokens to account `to`.
-	 *
-	 * Emits a {Transfer} event.
-	 */
+	/// @dev Mints `amount` tokens to account `to`.
+	/// @notice Emits a {Transfer} event.
 	function mint(address to, uint256 amount) external;
 
-	/**
-	 * @dev Moves `amount` tokens from the caller's account to `recipient`.
-	 *
-	 * Returns a boolean value indicating whether the operation succeeded.
-	 *
-	 * Emits a {Transfer} event.
-	 */
+	/// @dev Moves `amount` tokens from the caller's account to `recipient`.
+	/// @dev Returns a boolean value indicating whether the operation succeeded.
+	/// @notice Emits a {Transfer} event.
 	function transfer(address recipient, uint256 amount) external returns (bool);
 
-	/**
-	 * @dev Moves `amount` tokens from `sender` to `recipient` using the
-	 * allowance mechanism. `amount` is then deducted from the caller's
-	 * allowance.
-	 *
-	 * Returns a boolean value indicating whether the operation succeeded.
-	 *
-	 * Emits a {Transfer} event.
-	 */
+	/// @dev Moves `amount` tokens from `sender` to `recipient` using theallowance mechanism. `amount` is then deducted from the caller'sallowance.
+	/// @dev Returns a boolean value indicating whether the operation succeeded.
+	/// @notice Emits a {Transfer} event.
 	function transferFrom(
 		address sender,
 		address recipient,

--- a/packages/contracts/contracts/interfaces/tokens/ITokenWrapper.sol
+++ b/packages/contracts/contracts/interfaces/tokens/ITokenWrapper.sol
@@ -5,49 +5,38 @@
 
 pragma solidity ^0.8.18;
 
-/**
-    @title Interface for Token Wrapper contract.
-    @author Webb Technologies.
- */
+/// @title Interface for Token Wrapper contract.
+/// @author Webb Technologies.
+/// @notice This contract is meant to be used with the `TokenWrapper` contract.
 interface ITokenWrapper {
-	/**
-        @notice Wraps an `amount` of tokens from `tokenAddress`
-        @param _tokenAddress Address of the token to wrap
-        @param _amount Amount of tokens to wrap
-     */
+	/// @notice Wraps an `amount` of tokens from `tokenAddress`
+	/// @param _tokenAddress Address of the token to wrap
+	/// @param _amount Amount of tokens to wrap
 	function wrap(address _tokenAddress, uint256 _amount) external payable;
 
-	/**
-        @notice Unwraps an `amount` of an underlying token into the token at `tokenAddress`
-        @param _tokenAddress Address of the token to unwrap into
-        @param _amount Amount of tokens to unwrap
-     */
+	/// @notice Unwraps an `amount` of an underlying token into the token at `tokenAddress`
+	/// @param _tokenAddress Address of the token to unwrap into
+	/// @param _amount Amount of tokens to unwrap
 	function unwrap(address _tokenAddress, uint256 _amount) external;
 
-	/**
-        @notice Unwraps an `amount` of an underlying token into the token at `tokenAddress`
-        and sends to a `recipient` address
-        @param _tokenAddress Address of the token to unwrap into
-        @param _amount Amount of tokens to unwrap
-        @param _recipient Address of the recipient
-     */
+	/// @notice Unwraps an `amount` of an underlying token into the token at `tokenAddress`
+	/// and sends to a `recipient` address
+	/// @param _tokenAddress Address of the token to unwrap into
+	/// @param _amount Amount of tokens to unwrap
+	/// @param _recipient Address of the recipient
 	function unwrapAndSendTo(address _tokenAddress, uint256 _amount, address _recipient) external;
 
-	/**
-        @notice Wraps an `amount` of tokens from `tokenAddress` for the `sender`
-        @param _sender The sender address the tokens are being wrapped for
-        @param _tokenAddress Address of the token to wrap
-        @param _amount Amount of tokens to wrap
-     */
+	/// @notice Wraps an `amount` of tokens from `tokenAddress` for the `sender`
+	/// @param _sender The sender address the tokens are being wrapped for
+	/// @param _tokenAddress Address of the token to wrap
+	/// @param _amount Amount of tokens to wrap
 	function wrapFor(address _sender, address _tokenAddress, uint256 _amount) external payable;
 
-	/**
-        @notice Wraps an `amount of tokens from `tokenAddress` for the `sender` address and sends to a `_mintRecipient` 
-        @param _sender The sender address the tokens are being wrapped for
-        @param _tokenAddress Address of the token to wrap
-        @param _amount Amount of tokens to wrap
-        @param _mintRecipient Address of the recipient of the wrapped tokens
-     */
+	/// @notice Wraps an `amount of tokens from `tokenAddress` for the `sender` address and sends to a `_mintRecipient` 
+	/// @param _sender The sender address the tokens are being wrapped for
+	/// @param _tokenAddress Address of the token to wrap
+	/// @param _amount Amount of tokens to wrap
+	/// @param _mintRecipient Address of the recipient of the wrapped tokens
 	function wrapForAndSendTo(
 		address _sender,
 		address _tokenAddress,
@@ -55,31 +44,23 @@ interface ITokenWrapper {
 		address _mintRecipient
 	) external payable;
 
-	/**
-        @notice Unwraps an `amount` of an underlying token into the token at `tokenAddress` for a `sender`
-        @param _sender The sender address the tokens are being unwrapped for
-        @param _tokenAddress Address of the token to unwrap into
-        @param _amount Amount of tokens to unwrap
-     */
+	/// @notice Unwraps an `amount` of an underlying token into the token at `tokenAddress` for a `sender`
+	/// @param _sender The sender address the tokens are being unwrapped for
+	/// @param _tokenAddress Address of the token to unwrap into
+	/// @param _amount Amount of tokens to unwrap
 	function unwrapFor(address _sender, address _tokenAddress, uint256 _amount) external;
 
-	/**
-        @notice Gets the fee for an `_amountToWrap` amount of tokens
-        @param _amountToWrap Amount of tokens to wrap
-        @return uint256 The fee amount for the `_amountToWrap` amount of tokens
-     */
+	/// @notice Gets the fee for an `_amountToWrap` amount of tokens
+	/// @param _amountToWrap Amount of tokens to wrap
+	/// @return uint256 The fee amount for the `_amountToWrap` amount of tokens
 	function getFeeFromAmount(uint _amountToWrap) external view returns (uint);
 
-	/**
-        @notice Gets the amount to wrap for an exact `_deposit` amount of tokens. This
-        function calculates the amount needed to wrap inclusive of the fee that will
-        be charged from `getFeeFromAmount` to meet the `_deposit` amount
-        @param _deposit Amount of tokens needed for the deposit to be valid
-     */
+	/// @notice Gets the amount to wrap for an exact `_deposit` amount of tokens. This
+	/// function calculates the amount needed to wrap inclusive of the fee that will
+	/// be charged from `getFeeFromAmount` to meet the `_deposit` amount
+	/// @param _deposit Amount of tokens needed for the deposit to be valid
 	function getAmountToWrap(uint _deposit) external view returns (uint);
 
-	/**
-        @notice Checks if a token is wrappable / valid
-     */
+	/// @notice Checks if a token is wrappable / valid
 	function isValidToken(address _tokenAddress) external view returns (bool);
 }

--- a/packages/contracts/contracts/interfaces/tokens/ITokenWrapper.sol
+++ b/packages/contracts/contracts/interfaces/tokens/ITokenWrapper.sol
@@ -32,7 +32,7 @@ interface ITokenWrapper {
 	/// @param _amount Amount of tokens to wrap
 	function wrapFor(address _sender, address _tokenAddress, uint256 _amount) external payable;
 
-	/// @notice Wraps an `amount of tokens from `tokenAddress` for the `sender` address and sends to a `_mintRecipient` 
+	/// @notice Wraps an `amount of tokens from `tokenAddress` for the `sender` address and sends to a `_mintRecipient`
 	/// @param _sender The sender address the tokens are being wrapped for
 	/// @param _tokenAddress Address of the token to wrap
 	/// @param _amount Amount of tokens to wrap

--- a/packages/contracts/contracts/interfaces/verifiers/IAnchorVerifier.sol
+++ b/packages/contracts/contracts/interfaces/verifiers/IAnchorVerifier.sol
@@ -5,10 +5,9 @@
 
 pragma solidity ^0.8.18;
 
-/**
-    @title IAnchorVerifier interface
-    @notice A generic interface for verifying zero-knowledge proofs for anchors of different sizes.
- */
+/// @title IAnchorVerifier interface
+/// @notice A generic interface for verifying zero-knowledge proofs for anchors of different sizes.
+/// @dev This contract is meant to be used with the `VAnchor` contract.
 interface IAnchorVerifier {
 	function verifyProof(
 		uint[2] memory a,

--- a/packages/contracts/contracts/interfaces/verifiers/ISetVerifier.sol
+++ b/packages/contracts/contracts/interfaces/verifiers/ISetVerifier.sol
@@ -5,14 +5,12 @@
 
 pragma solidity ^0.8.18;
 
-/**
-    @title Interface for setting the verifier for a contract.
- */
+/// @title Interface for setting the verifier for a contract.
+/// @author Webb Technologies.
+/// @notice This contract is meant to be used with the `VAnchor` contract.
 interface ISetVerifier {
-	/**
-        @notice Sets the verifier for the contract
-        @param verifier The new verifier address
-        @param nonce The nonce for tracking update counts
-     */
+	/// @notice Sets the verifier for the contract
+	/// @param verifier The new verifier address
+	/// @param nonce The nonce for tracking update counts
 	function setVerifier(address verifier, uint32 nonce) external;
 }

--- a/packages/contracts/contracts/interfaces/verifiers/IVAnchorVerifier.sol
+++ b/packages/contracts/contracts/interfaces/verifiers/IVAnchorVerifier.sol
@@ -5,14 +5,13 @@
 
 pragma solidity ^0.8.18;
 
-/**
-    @title IVAnchorVerifier join/split verifier interface with 2 edges
-    and 2 inputs to 2 outputs.
 
-    The X_Y (2_2) identifiers designate the following:
-    - X is the # of edges supported on this VAnchor (i.e. 2)
-    - Y is the # of inputs to the join/split transaction (i.e. 2)
- */
+/// @title IVAnchorVerifier join/split verifier interface with 2 edges
+/// @author Webb Technologies.
+/// and 2 inputs to 2 outputs.
+/// @notice The X_Y (2_2) identifiers designate the following:
+/// - X is the # of edges supported on this VAnchor (i.e. 2)
+/// - Y is the # of inputs to the join/split transaction (i.e. 2)
 interface IVAnchorVerifier2_2 {
 	function verifyProof(
 		uint[2] memory a,
@@ -22,14 +21,12 @@ interface IVAnchorVerifier2_2 {
 	) external view returns (bool r);
 }
 
-/**
-    @title IVAnchorVerifier join/split verifier interface with 2 edges
-    and 16 inputs to 2 outputs.
-
-    The X_Y (2_16) identifiers designate the following:
-    - X is the # of edges supported on this VAnchor (i.e. 2)
-    - Y is the # of inputs to the join/split transaction (i.e. 16)
- */
+/// @title IVAnchorVerifier join/split verifier interface with 2 edges
+/// @author Webb Technologies.
+/// and 16 inputs to 2 outputs.
+/// @notice The X_Y (2_16) identifiers designate the following:
+/// - X is the # of edges supported on this VAnchor (i.e. 2)
+/// - Y is the # of inputs to the join/split transaction (i.e. 16)
 interface IVAnchorVerifier2_16 {
 	function verifyProof(
 		uint[2] memory a,
@@ -39,14 +36,12 @@ interface IVAnchorVerifier2_16 {
 	) external view returns (bool r);
 }
 
-/**
-    @title IVAnchorVerifier join/split verifier interface with 8 edges
-    and 2 inputs to 2 outputs.
-
-    The X_Y (8_2) identifiers designate the following:
-    - X is the # of edges supported on this VAnchor (i.e. 8)
-    - Y is the # of inputs to the join/split transaction (i.e. 2)
- */
+/// @title IVAnchorVerifier join/split verifier interface with 8 edges
+/// @author Webb Technologies.
+/// and 2 inputs to 2 outputs.
+/// @notice The X_Y (8_2) identifiers designate the following:
+/// - X is the # of edges supported on this VAnchor (i.e. 8)
+/// - Y is the # of inputs to the join/split transaction (i.e. 2)
 interface IVAnchorVerifier8_2 {
 	function verifyProof(
 		uint[2] memory a,
@@ -56,14 +51,12 @@ interface IVAnchorVerifier8_2 {
 	) external view returns (bool r);
 }
 
-/**
-    @title IVAnchorVerifier join/split verifier interface with 2 edges
-    and 2 inputs to 2 outputs.
-
-    The X_Y (8_16) identifiers designate the following:
-    - X is the # of edges supported on this VAnchor (i.e. 8)
-    - Y is the # of inputs to the join/split transaction (i.e. 16)
- */
+/// @title IVAnchorVerifier join/split verifier interface with 2 edges
+/// @author Webb Technologies.
+/// and 2 inputs to 2 outputs.
+/// @notice The X_Y (8_16) identifiers designate the following:
+/// - X is the # of edges supported on this VAnchor (i.e. 8)
+/// - Y is the # of inputs to the join/split transaction (i.e. 16)
 interface IVAnchorVerifier8_16 {
 	function verifyProof(
 		uint[2] memory a,

--- a/packages/contracts/contracts/interfaces/verifiers/IVAnchorVerifier.sol
+++ b/packages/contracts/contracts/interfaces/verifiers/IVAnchorVerifier.sol
@@ -5,7 +5,6 @@
 
 pragma solidity ^0.8.18;
 
-
 /// @title IVAnchorVerifier join/split verifier interface with 2 edges
 /// @author Webb Technologies.
 /// and 2 inputs to 2 outputs.

--- a/packages/contracts/contracts/libs/VAnchorEncodeInputs.sol
+++ b/packages/contracts/contracts/libs/VAnchorEncodeInputs.sol
@@ -14,13 +14,13 @@ import "../structs/PublicInputs.sol";
 library VAnchorEncodeInputs {
 	bytes2 public constant EVM_CHAIN_ID_TYPE = 0x0100;
 
-    /// @notice Proof struct for VAnchor proofs
-    /// @param proof The zkSNARK proof data
-    /// @param roots The roots on the VAnchor bridge to verify the proof against
-    /// @param inputNullifiers The nullifiers of the UTXO 
-    /// @param outputCommitments The 2 new commitments for the join/split UTXO transaction
-    /// @param publicAmount The public amount being deposited to this VAnchor
-    /// @param extDataHash The external data hash for the proof verification
+	/// @notice Proof struct for VAnchor proofs
+	/// @param proof The zkSNARK proof data
+	/// @param roots The roots on the VAnchor bridge to verify the proof against
+	/// @param inputNullifiers The nullifiers of the UTXO
+	/// @param outputCommitments The 2 new commitments for the join/split UTXO transaction
+	/// @param publicAmount The public amount being deposited to this VAnchor
+	/// @param extDataHash The external data hash for the proof verification
 	struct Proof {
 		bytes proof;
 		bytes roots;
@@ -30,7 +30,7 @@ library VAnchorEncodeInputs {
 		bytes32 extDataHash;
 	}
 
-    /// @notice Gets the chain id using the chain id opcode
+	/// @notice Gets the chain id using the chain id opcode
 	function getChainId() public view returns (uint) {
 		uint chainId;
 		assembly {
@@ -39,7 +39,7 @@ library VAnchorEncodeInputs {
 		return chainId;
 	}
 
-    /// @notice Computes the modified chain id using the underlying chain type (EVM)
+	/// @notice Computes the modified chain id using the underlying chain type (EVM)
 	function getChainIdType() public view returns (uint48) {
 		// The chain ID and type pair is 6 bytes in length
 		// The first 2 bytes are reserved for the chain type.
@@ -53,10 +53,10 @@ library VAnchorEncodeInputs {
 		return uint48(bytes6(chainIdWithType));
 	}
 
-    /// @notice Encodes the proof into its public inputs and roots array for 2 input / 2 output txes
-    /// @param _args The proof arguments
-    /// @param _maxEdges The maximum # of edges supported by the underlying VAnchor
-    /// @return (bytes, bytes) The public inputs and roots array separated
+	/// @notice Encodes the proof into its public inputs and roots array for 2 input / 2 output txes
+	/// @param _args The proof arguments
+	/// @param _maxEdges The maximum # of edges supported by the underlying VAnchor
+	/// @return (bytes, bytes) The public inputs and roots array separated
 	function _encodeInputs2(
 		PublicInputs memory _args,
 		bytes memory,
@@ -119,10 +119,10 @@ library VAnchorEncodeInputs {
 		return (encodedInput, result);
 	}
 
-    /// @notice Encodes the proof into its public inputs and roots array for 16 input / 2 output txes
-    /// @param _args The proof arguments
-    /// @param _maxEdges The maximum # of edges supported by the underlying VAnchor
-    /// @return (bytes, bytes) The public inputs and roots array separated
+	/// @notice Encodes the proof into its public inputs and roots array for 16 input / 2 output txes
+	/// @param _args The proof arguments
+	/// @param _maxEdges The maximum # of edges supported by the underlying VAnchor
+	/// @return (bytes, bytes) The public inputs and roots array separated
 	function _encodeInputs16(
 		PublicInputs memory _args,
 		bytes memory,

--- a/packages/contracts/contracts/libs/VAnchorEncodeInputs.sol
+++ b/packages/contracts/contracts/libs/VAnchorEncodeInputs.sol
@@ -8,21 +8,19 @@ pragma experimental ABIEncoderV2;
 
 import "../structs/PublicInputs.sol";
 
-/**
-    @title VAnchorEncodeInputs library for encoding inputs for VAnchor proofs
- */
+/// @title VAnchorEncodeInputs library for encoding inputs for VAnchor proofs
+/// @author Webb Technologies.
+/// @notice This contract is meant to be used with the `VAnchor` contract.
 library VAnchorEncodeInputs {
 	bytes2 public constant EVM_CHAIN_ID_TYPE = 0x0100;
 
-	/**
-        @notice Proof struct for VAnchor proofs
-        @param proof The zkSNARK proof data
-        @param roots The roots on the VAnchor bridge to verify the proof against
-        @param inputNullifiers The nullifiers of the UTXO 
-        @param outputCommitments The 2 new commitments for the join/split UTXO transaction
-        @param publicAmount The public amount being deposited to this VAnchor
-        @param extDataHash The external data hash for the proof verification
-    */
+    /// @notice Proof struct for VAnchor proofs
+    /// @param proof The zkSNARK proof data
+    /// @param roots The roots on the VAnchor bridge to verify the proof against
+    /// @param inputNullifiers The nullifiers of the UTXO 
+    /// @param outputCommitments The 2 new commitments for the join/split UTXO transaction
+    /// @param publicAmount The public amount being deposited to this VAnchor
+    /// @param extDataHash The external data hash for the proof verification
 	struct Proof {
 		bytes proof;
 		bytes roots;
@@ -32,9 +30,7 @@ library VAnchorEncodeInputs {
 		bytes32 extDataHash;
 	}
 
-	/**
-        @notice Gets the chain id using the chain id opcode
-     */
+    /// @notice Gets the chain id using the chain id opcode
 	function getChainId() public view returns (uint) {
 		uint chainId;
 		assembly {
@@ -43,9 +39,7 @@ library VAnchorEncodeInputs {
 		return chainId;
 	}
 
-	/**
-        @notice Computes the modified chain id using the underlying chain type (EVM)
-     */
+    /// @notice Computes the modified chain id using the underlying chain type (EVM)
 	function getChainIdType() public view returns (uint48) {
 		// The chain ID and type pair is 6 bytes in length
 		// The first 2 bytes are reserved for the chain type.
@@ -59,12 +53,10 @@ library VAnchorEncodeInputs {
 		return uint48(bytes6(chainIdWithType));
 	}
 
-	/**
-        @notice Encodes the proof into its public inputs and roots array for 2 input / 2 output txes
-        @param _args The proof arguments
-        @param _maxEdges The maximum # of edges supported by the underlying VAnchor
-        @return (bytes, bytes) The public inputs and roots array separated
-     */
+    /// @notice Encodes the proof into its public inputs and roots array for 2 input / 2 output txes
+    /// @param _args The proof arguments
+    /// @param _maxEdges The maximum # of edges supported by the underlying VAnchor
+    /// @return (bytes, bytes) The public inputs and roots array separated
 	function _encodeInputs2(
 		PublicInputs memory _args,
 		bytes memory,
@@ -121,18 +113,16 @@ library VAnchorEncodeInputs {
 			inputs[14] = uint256(roots[7]);
 			encodedInput = abi.encodePacked(inputs);
 		} else {
-			require(false, "Invalid edges");
+			require(false, "VAnchorEncodeInputs: Invalid edges");
 		}
 
 		return (encodedInput, result);
 	}
 
-	/**
-        @notice Encodes the proof into its public inputs and roots array for 16 input / 2 output txes
-        @param _args The proof arguments
-        @param _maxEdges The maximum # of edges supported by the underlying VAnchor
-        @return (bytes, bytes) The public inputs and roots array separated
-     */
+    /// @notice Encodes the proof into its public inputs and roots array for 16 input / 2 output txes
+    /// @param _args The proof arguments
+    /// @param _maxEdges The maximum # of edges supported by the underlying VAnchor
+    /// @return (bytes, bytes) The public inputs and roots array separated
 	function _encodeInputs16(
 		PublicInputs memory _args,
 		bytes memory,
@@ -218,7 +208,7 @@ library VAnchorEncodeInputs {
 			inputs[28] = uint256(roots[7]);
 			encodedInput = abi.encodePacked(inputs);
 		} else {
-			require(false, "Invalid edges");
+			require(false, "VAnchorEncodeInputs: Invalid edges");
 		}
 
 		return (encodedInput, result);

--- a/packages/contracts/contracts/mocks/MerkleTreeMock.sol
+++ b/packages/contracts/contracts/mocks/MerkleTreeMock.sol
@@ -7,7 +7,7 @@ pragma solidity ^0.8.18;
 import "../trees/MerkleTree.sol";
 import "../hashers/IHasher.sol";
 
-contract MerkleTreePoseidonMock is MerkleTree {
+contract MerkleTreeMock is MerkleTree {
 	constructor(uint32 _treeLevels, IHasher _hasher) MerkleTree(_treeLevels, _hasher) {}
 
 	function insert(uint256 _leaf) public {

--- a/packages/contracts/contracts/structs/Edge.sol
+++ b/packages/contracts/contracts/structs/Edge.sol
@@ -5,13 +5,11 @@
 
 pragma solidity ^0.8.18;
 
-/**
-    @dev The Edge struct is used to store the edge data for linkable tree connections.
-    @param chainId The chain id where the LinkableTree contract being linked is located.
-    @param root The latest merkle root of the LinkableTree contract being linked.
-    @param nonce The latest leaf insertion index of the LinkableTree contract being linked.
-    @param srcResourceID The contract address or tree identifier of the LinkableTree being linked.
-*/
+/// @dev The Edge struct is used to store the edge data for linkable tree connections.
+/// @param chainId The chain id where the LinkableTree contract being linked is located.
+/// @param root The latest merkle root of the LinkableTree contract being linked.
+/// @param nonce The latest leaf insertion index of the LinkableTree contract being linked.
+/// @param srcResourceID The contract address or tree identifier of the LinkableTree being linked.
 struct Edge {
 	uint256 chainID;
 	uint256 root;

--- a/packages/contracts/contracts/structs/PublicInputs.sol
+++ b/packages/contracts/contracts/structs/PublicInputs.sol
@@ -5,6 +5,17 @@
 
 pragma solidity ^0.8.18;
 
+/// @title Common structs for public inputs and shielded transactions.
+/// @author Webb Technologies.
+/// @notice These structs are meant to be used with the `VAnchor` contract.
+
+/// @notice Common external data for all transactions
+/// @param recipient The recipient of the transaction
+/// @param extAmount The external amount being transferred
+/// @param relayer The relayer of the transaction
+/// @param fee The fee for the transaction
+/// @param refund The refund for the transaction
+/// @param token The token being wrapped/unwrapped or transferred if its the shielded pool token
 struct CommonExtData {
 	address recipient;
 	int256 extAmount;
@@ -14,15 +25,13 @@ struct CommonExtData {
 	address token;
 }
 
-/**
-    @notice Public input struct for VAnchor proofs
-    @param roots The roots on the VAnchor commitment trees
-    @param extensionRoots The extra roots for extension VAnchors such as IdentityVAnchor
-    @param inputNullifiers The nullifiers of the UTXO records
-    @param outputCommitments The 2 new commitments for the join/split UTXO transaction
-    @param publicAmount The public amount being deposited to this VAnchor
-    @param extDataHash The external data hash for the proof verification
-*/
+/// @notice Public input struct for VAnchor proofs
+/// @param roots The roots on the VAnchor commitment trees
+/// @param extensionRoots The extra roots for extension VAnchors such as IdentityVAnchor
+/// @param inputNullifiers The nullifiers of the UTXO records
+/// @param outputCommitments The 2 new commitments for the join/split UTXO transaction
+/// @param publicAmount The public amount being deposited to this VAnchor
+/// @param extDataHash The external data hash for the proof verification
 struct PublicInputs {
 	bytes roots;
 	bytes extensionRoots;
@@ -32,9 +41,7 @@ struct PublicInputs {
 	uint256 extDataHash;
 }
 
-/**
-    @notice External encryptions for new output commitments
- */
+/// @notice External encryptions for new output commitments
 struct Encryptions {
 	bytes encryptedOutput1;
 	bytes encryptedOutput2;

--- a/packages/contracts/contracts/structs/SingleAssetExtData.sol
+++ b/packages/contracts/contracts/structs/SingleAssetExtData.sol
@@ -5,6 +5,19 @@
 
 pragma solidity ^0.8.18;
 
+/// @title SingleAssetExtData struct for encoding external data for single asset proofs
+/// @author Webb Technologies.
+/// @notice This contract is meant to be used to encode external data for hashing to verify proofs.
+
+/// @dev The SingleAssetExtData struct is used to store the external data for single asset proofs.
+/// @param recipient The recipient of the transaction
+/// @param extAmount The external amount being transferred
+/// @param relayer The relayer of the transaction
+/// @param fee The fee for the transaction
+/// @param refund The refund for the transaction
+/// @param token The token being wrapped/unwrapped or transferred if its the shielded pool token
+/// @param encryptedOutput1 The encrypted output 1 for the transaction
+/// @param encryptedOutput2 The encrypted output 2 for the transaction
 struct ExtData {
 	address recipient;
 	int256 extAmount;

--- a/packages/contracts/contracts/test/Governable.t.sol
+++ b/packages/contracts/contracts/test/Governable.t.sol
@@ -1,0 +1,314 @@
+/**
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+pragma solidity >=0.8.19 <0.9.0;
+
+import { PRBTest } from "@prb/test/PRBTest.sol";
+import { console2 } from "forge-std/console2.sol";
+import { StdCheats } from "forge-std/StdCheats.sol";
+
+import { Governable, Vote } from "../utils/Governable.sol";
+import { MerkleTreeMock as MerkleTree } from "../mocks/MerkleTreeMock.sol";
+import { KeccakHasher } from "../hashers/KeccakHasher.sol";
+import { ProposalHelpers } from "./ProposalHelpers.t.sol";
+
+contract GovernableTest is PRBTest, StdCheats, ProposalHelpers {
+	Governable governableContract;
+	KeccakHasher hasher;
+	MerkleTree tree;
+
+	uint32 refreshNonce;
+
+	address alice;
+	address governor;
+
+	function setUp() public virtual {
+		alice = vm.addr(1);
+		governor = alice;
+
+		refreshNonce = 0;
+		governableContract = new Governable(governor, refreshNonce);
+
+		hasher = new KeccakHasher();
+		tree = new MerkleTree(2, hasher);
+	}
+
+	function signWithGoverner(bytes memory data) public view returns (bytes memory) {
+		(uint8 v, bytes32 r, bytes32 s) = vm.sign(1, keccak256(data));
+		return abi.encodePacked(r, s, v);
+	}
+
+	function test_transferOwnership(address newGovernor) public {
+		vm.prank(governor);
+		governableContract.transferOwnership(newGovernor, refreshNonce + 1);
+		assertEq(governableContract.governor(), newGovernor);
+		assertEq(governableContract.refreshNonce(), refreshNonce + 1);
+	}
+
+	function test_transferOwnershipShouldFailFromNotGovernor(address newGovernor) public {
+		vm.prank(vm.addr(2));
+		vm.expectRevert(bytes("Governable: caller is not the governor"));
+		governableContract.transferOwnership(newGovernor, refreshNonce + 1);
+	}
+
+	function test_transferOwnershipShouldFailIfTransferringToZero() public {
+		vm.prank(governor);
+		vm.expectRevert(bytes("Governable: New governor is the zero address"));
+		governableContract.transferOwnership(address(0x0), refreshNonce + 1);
+	}
+
+	function test_transferOwnershipWithSignature() public {
+		string
+			memory pubkeyString = "989f3c75d99033df6074a25c7255629da79c57fd5379bcb6e2438d2bf339e1511a71de858155b44efcbe1f7621693fae07e57a531799a38c4d00e2904389e938";
+		bytes memory pubkey = fromHex(pubkeyString);
+		address newGovernor = 0xe725B59239D1b324CF0e0a93473009A155167733;
+		bytes memory sig = signWithGoverner(abi.encodePacked(refreshNonce + 1, pubkey));
+		vm.prank(governor);
+		governableContract.transferOwnershipWithSignaturePubKey(pubkey, refreshNonce + 1, sig);
+		assertEq(governableContract.governor(), newGovernor);
+		assertEq(governableContract.refreshNonce(), refreshNonce + 1);
+	}
+
+	function test_transferOwnershipWithSignatureShouldFailWithInvalidNonce() public {
+		string
+			memory pubkeyString = "989f3c75d99033df6074a25c7255629da79c57fd5379bcb6e2438d2bf339e1511a71de858155b44efcbe1f7621693fae07e57a531799a38c4d00e2904389e938";
+		bytes memory pubkey = fromHex(pubkeyString);
+		address newGovernor = 0xe725B59239D1b324CF0e0a93473009A155167733;
+		bytes memory sig = signWithGoverner(abi.encodePacked(newGovernor, refreshNonce + 2));
+		vm.prank(governor);
+		vm.expectRevert(bytes("Governable: Nonce must increment by 1"));
+		governableContract.transferOwnershipWithSignaturePubKey(pubkey, refreshNonce + 2, sig);
+	}
+
+	function test_proposerSetUpdate(address[4] memory proposers) public {
+		for (uint i = 0; i < proposers.length; i++) {
+			tree.insert(uint256(keccak256(abi.encodePacked(proposers[i]))));
+		}
+
+		bytes32 merkleRoot = bytes32(tree.getLastRoot());
+		uint64 averageSessionLengthInMillisecs = 50000;
+		uint32 numOfProposers = 4;
+		uint32 proposerSetUpdateNonce = 1;
+		bytes memory proposerSetUpdate = buildProposerSetUpdateProposal(
+			merkleRoot,
+			averageSessionLengthInMillisecs,
+			numOfProposers,
+			proposerSetUpdateNonce
+		);
+
+		bytes memory sig = signWithGoverner(proposerSetUpdate);
+
+		vm.prank(governor);
+		governableContract.updateProposerSetData(
+			merkleRoot,
+			averageSessionLengthInMillisecs,
+			numOfProposers,
+			proposerSetUpdateNonce,
+			sig
+		);
+
+		assertEq(governableContract.proposerSetUpdateNonce(), proposerSetUpdateNonce);
+		assertEq(governableContract.proposerSetRoot(), merkleRoot);
+		assertEq(
+			governableContract.averageSessionLengthInMillisecs(),
+			averageSessionLengthInMillisecs
+		);
+		assertEq(governableContract.numOfProposers(), numOfProposers);
+		assertEq(governableContract.currentVotingPeriod(), 1);
+	}
+
+	function test_proposerSetUpdateForceChangeGovernor() public {
+		address[] memory proposers = new address[](4);
+
+		for (uint256 i = 0; i < 4; i++) {
+			address proposer = vm.addr(uint256(keccak256(abi.encodePacked(i))));
+			vm.deal(proposer, 100 ether);
+			proposers[i] = proposer;
+		}
+
+		for (uint i = 0; i < proposers.length; i++) {
+			tree.insert(uint256(keccak256(abi.encodePacked(proposers[i]))));
+		}
+
+		bytes32 merkleRoot = bytes32(tree.getLastRoot());
+		uint64 averageSessionLengthInMillisecs = 50000;
+		uint32 numOfProposers = 4;
+		uint32 proposerSetUpdateNonce = 1;
+		bytes memory proposerSetUpdate = buildProposerSetUpdateProposal(
+			merkleRoot,
+			averageSessionLengthInMillisecs,
+			numOfProposers,
+			proposerSetUpdateNonce
+		);
+
+		bytes memory sig = signWithGoverner(proposerSetUpdate);
+
+		vm.prank(governor);
+		governableContract.updateProposerSetData(
+			merkleRoot,
+			averageSessionLengthInMillisecs,
+			numOfProposers,
+			proposerSetUpdateNonce,
+			sig
+		);
+
+		// Now execute the voting protocol
+		vm.warp(
+			block.timestamp +
+				averageSessionLengthInMillisecs *
+				governableContract.sessionLengthMultiplier()
+		);
+		address newGovernor = vm.addr(2);
+		// We only need a majority of votes so we can skip the last proposer
+		for (uint i = 0; i < proposers.length - 1; i++) {
+			bytes32[] memory path = getPathForLeaf(proposers, i, merkleRoot);
+			Vote memory vote = governableContract.createVote(uint32(i), newGovernor, path);
+			vm.prank(proposers[i]);
+			governableContract.voteInFavorForceSetGovernor(vote);
+		}
+
+		assertEq(governableContract.governor(), newGovernor);
+		assertEq(governableContract.currentVotingPeriod(), 2);
+	}
+
+	function test_proposerSetUpdateForceChangeGovernorWithSig() public {
+		address[] memory proposers = new address[](4);
+
+		for (uint256 i = 0; i < 4; i++) {
+			address proposer = vm.addr(uint256(keccak256(abi.encodePacked(i))));
+			vm.deal(proposer, 100 ether);
+			proposers[i] = proposer;
+		}
+
+		for (uint i = 0; i < proposers.length; i++) {
+			tree.insert(uint256(keccak256(abi.encodePacked(proposers[i]))));
+		}
+
+		bytes32 merkleRoot = bytes32(tree.getLastRoot());
+		uint64 averageSessionLengthInMillisecs = 50000;
+		uint32 numOfProposers = 4;
+		uint32 proposerSetUpdateNonce = 1;
+		bytes memory proposerSetUpdate = buildProposerSetUpdateProposal(
+			merkleRoot,
+			averageSessionLengthInMillisecs,
+			numOfProposers,
+			proposerSetUpdateNonce
+		);
+
+		bytes memory sig = signWithGoverner(proposerSetUpdate);
+
+		vm.prank(governor);
+		governableContract.updateProposerSetData(
+			merkleRoot,
+			averageSessionLengthInMillisecs,
+			numOfProposers,
+			proposerSetUpdateNonce,
+			sig
+		);
+
+		// Now execute the voting protocol
+		vm.warp(
+			block.timestamp +
+				averageSessionLengthInMillisecs *
+				governableContract.sessionLengthMultiplier()
+		);
+		address newGovernor = vm.addr(2);
+		// We only need a majority of votes so we can skip the last proposer
+		Vote[] memory votes = new Vote[](proposers.length - 1);
+		bytes[] memory sigs = new bytes[](proposers.length - 1);
+		for (uint i = 0; i < proposers.length - 1; i++) {
+			bytes32[] memory path = getPathForLeaf(proposers, i, merkleRoot);
+			Vote memory vote = governableContract.createVote(uint32(i), newGovernor, path);
+			// Sign the vote with the proposer's key
+			(uint8 v, bytes32 r, bytes32 s) = vm.sign(
+				uint256(keccak256(abi.encodePacked(i))),
+				keccak256(abi.encode(vote))
+			);
+			bytes memory sig = abi.encodePacked(r, s, v);
+			votes[i] = vote;
+			sigs[i] = sig;
+		}
+		// Submit the votes and signatures
+		governableContract.voteInFavorForceSetGovernorWithSig(votes, sigs);
+		assertEq(governableContract.governor(), newGovernor);
+		assertEq(governableContract.currentVotingPeriod(), 2);
+	}
+
+	// Convert an hexadecimal character to their value
+	function fromHexChar(uint8 c) public pure returns (uint8) {
+		if (bytes1(c) >= bytes1("0") && bytes1(c) <= bytes1("9")) {
+			return c - uint8(bytes1("0"));
+		}
+		if (bytes1(c) >= bytes1("a") && bytes1(c) <= bytes1("f")) {
+			return 10 + c - uint8(bytes1("a"));
+		}
+		if (bytes1(c) >= bytes1("A") && bytes1(c) <= bytes1("F")) {
+			return 10 + c - uint8(bytes1("A"));
+		}
+		revert("fail");
+	}
+
+	// Convert an hexadecimal string to raw bytes
+	function fromHex(string memory s) public pure returns (bytes memory) {
+		bytes memory ss = bytes(s);
+		require(ss.length % 2 == 0); // length must be even
+		bytes memory r = new bytes(ss.length / 2);
+		for (uint i = 0; i < ss.length / 2; ++i) {
+			r[i] = bytes1(fromHexChar(uint8(ss[2 * i])) * 16 + fromHexChar(uint8(ss[2 * i + 1])));
+		}
+		return r;
+	}
+
+	/// Calculate the merkle path for a given node given all the leaves, the index we want
+	/// to prove, and the root to check against to ensure we have the correct path.
+	function getPathForLeaf(
+		address[] memory proposers,
+		uint index,
+		bytes32 root
+	) public returns (bytes32[] memory) {
+		bytes32[4] memory firstLayer = [
+			keccak256(abi.encodePacked(proposers[0])),
+			keccak256(abi.encodePacked(proposers[1])),
+			keccak256(abi.encodePacked(proposers[2])),
+			keccak256(abi.encodePacked(proposers[3]))
+		];
+		bytes32[2] memory secondLayer = [
+			keccak256(abi.encodePacked(firstLayer[0], firstLayer[1])),
+			keccak256(abi.encodePacked(firstLayer[2], firstLayer[3]))
+		];
+
+		bytes32 calculatedRoot = keccak256(abi.encodePacked(secondLayer[0], secondLayer[1]));
+		require(calculatedRoot == root, "Invalid root");
+
+		bytes32[] memory siblingPath = new bytes32[](2);
+		if (index == 0) {
+			siblingPath[0] = firstLayer[1];
+			siblingPath[1] = secondLayer[1];
+		} else if (index == 1) {
+			siblingPath[0] = firstLayer[0];
+			siblingPath[1] = secondLayer[1];
+		} else if (index == 2) {
+			siblingPath[0] = firstLayer[3];
+			siblingPath[1] = secondLayer[0];
+		} else if (index == 3) {
+			siblingPath[0] = firstLayer[2];
+			siblingPath[1] = secondLayer[0];
+		} else {
+			revert("Invalid index");
+		}
+
+		// Verify the sibling path
+		bytes32 currNodeHash = firstLayer[index];
+		uint nextIndex = index;
+		for (uint i = 0; i < siblingPath.length; i++) {
+			if (nextIndex % 2 == 0) {
+				currNodeHash = keccak256(abi.encodePacked(currNodeHash, siblingPath[i]));
+			} else {
+				currNodeHash = keccak256(abi.encodePacked(siblingPath[i], currNodeHash));
+			}
+			nextIndex = nextIndex / 2;
+		}
+		require(currNodeHash == root, "Invalid sibling path");
+		return siblingPath;
+	}
+}

--- a/packages/contracts/contracts/test/ProposalHelpers.t.sol
+++ b/packages/contracts/contracts/test/ProposalHelpers.t.sol
@@ -89,4 +89,19 @@ contract ProposalHelpers is ChainIdWithType {
 		// Return the proposal header and proposal data concatenated
 		return buildProposal(proposalHeader, proposalData);
 	}
+
+	function buildProposerSetUpdateProposal(
+		bytes32 _proposerSetRoot,
+		uint64 _averageSessionLengthInMillisecs,
+		uint32 _numOfProposers,
+		uint32 _proposerSetUpdateNonce
+	) public pure returns (bytes memory) {
+		return
+			abi.encodePacked(
+				_proposerSetRoot,
+				bytes8(_averageSessionLengthInMillisecs),
+				bytes4(_numOfProposers),
+				bytes4(_proposerSetUpdateNonce)
+			);
+	}
 }

--- a/packages/contracts/contracts/tokens/AaveTokenWrapper.sol
+++ b/packages/contracts/contracts/tokens/AaveTokenWrapper.sol
@@ -9,34 +9,29 @@ import "./FungibleTokenWrapper.sol";
 import "../interfaces/tokens/IAaveTokenWrapper.sol";
 import "../interfaces/external/aave/IAaveLendingPool.sol";
 
-/**
-    @title An AaveTokenWrapper system that deposits/withdraws into Aave lending pools
-    @author Webb Technologies.
- */
+/// @title An AaveTokenWrapper system that deposits/withdraws into Aave lending pools
+/// @author Webb Technologies.
+/// @notice This contract is meant to be used over the `FungibleTokenWrapper` contract.
 contract AaveTokenWrapper is FungibleTokenWrapper, IAaveTokenWrapper {
 	IAaveLendingPool public aaveLendingPool;
 
-	/**
-        @notice AaveTokenWrapper constructor
-        @param _name The name of the ERC20 TokenWrapper
-        @param _symbol The symbol of the ERC20 TokenWrapper
-     */
+	/// @notice AaveTokenWrapper constructor
+	/// @param _name The name of the ERC20 TokenWrapper
+	/// @param _symbol The symbol of the ERC20 TokenWrapper
 	constructor(
 		string memory _name,
 		string memory _symbol,
 		address _aaveLendingPool
 	) FungibleTokenWrapper(_name, _symbol) {}
 
-	/**
-        @notice AaveTokenWrapper initializer
-        @param _feePercentage The fee percentage for wrapping
-        @param _feeRecipient The recipient for fees from wrapping.
-        @param _handler The address of the handler
-        @param _limit The maximum amount of tokens that can be wrapped
-        @param _isNativeAllowed Whether or not native tokens are allowed to be wrapped
-		@param _admin The address of the admin who will receive minting rights and admin role
-		@param _aaveLendingPool The address of the Aave lending pool
-     */
+	/// @notice AaveTokenWrapper initializer
+	/// @param _feePercentage The fee percentage for wrapping
+	/// @param _feeRecipient The recipient for fees from wrapping.
+	/// @param _handler The address of the handler
+	/// @param _limit The maximum amount of tokens that can be wrapped
+	/// @param _isNativeAllowed Whether or not native tokens are allowed to be wrapped
+	/// @param _admin The address of the admin who will receive minting rights and admin role
+	/// @param _aaveLendingPool The address of the Aave lending pool
 	function initialize(
 		uint16 _feePercentage,
 		address _feeRecipient,

--- a/packages/contracts/contracts/tokens/FungibleTokenWrapper.sol
+++ b/packages/contracts/contracts/tokens/FungibleTokenWrapper.sol
@@ -10,13 +10,11 @@ import "../interfaces/tokens/IFungibleTokenWrapper.sol";
 import "../utils/Initialized.sol";
 import "../utils/ProposalNonceTracker.sol";
 
-/**
-    @title A governed TokenWrapper system using an external `handler` address
-    @author Webb Technologies.
-    @notice Governs allowable ERC20s to deposit using a governable wrapping limit and
-    sets fees for wrapping into itself. This contract is intended to be used with
-    TokenHandler contract.
- */
+/// @title A governed TokenWrapper system using an external `handler` address
+/// @author Webb Technologies.
+/// @notice Governs allowable ERC20s to deposit using a governable wrapping limit and
+/// sets fees for wrapping into itself. This contract is intended to be used with
+/// TokenHandler contract.
 contract FungibleTokenWrapper is
 	Initialized,
 	TokenWrapper,
@@ -35,22 +33,18 @@ contract FungibleTokenWrapper is
 
 	event HandlerUpdated(address _handler);
 
-	/**
-        @notice FungibleTokenWrapper constructor
-        @param _name The name of the ERC20 TokenWrapper
-        @param _symbol The symbol of the ERC20 TokenWrapper
-     */
+	/// @notice FungibleTokenWrapper constructor
+	/// @param _name The name of the ERC20 TokenWrapper
+	/// @param _symbol The symbol of the ERC20 TokenWrapper
 	constructor(string memory _name, string memory _symbol) TokenWrapper(_name, _symbol) {}
 
-	/**
-        @notice FungibleTokenWrapper initializer
-        @param _feePercentage The fee percentage for wrapping
-        @param _feeRecipient The recipient for fees from wrapping.
-        @param _handler The address of the handler
-        @param _limit The maximum amount of tokens that can be wrapped
-        @param _isNativeAllowed Whether or not native tokens are allowed to be wrapped
-		@param _admin The address of the admin who will receive minting rights and admin role
-     */
+	/// @notice FungibleTokenWrapper initializer
+	/// @param _feePercentage The fee percentage for wrapping
+	/// @param _feeRecipient The recipient for fees from wrapping.
+	/// @param _handler The address of the handler
+	/// @param _limit The maximum amount of tokens that can be wrapped
+	/// @param _isNativeAllowed Whether or not native tokens are allowed to be wrapped
+	/// @param _admin The address of the admin who will receive minting rights and admin role
 	function initialize(
 		uint16 _feePercentage,
 		address _feeRecipient,
@@ -74,32 +68,26 @@ contract FungibleTokenWrapper is
 		isNativeAllowed = _isNativeAllowed;
 	}
 
-	/**
-        @notice Sets the handler of the FungibleTokenWrapper contract
-        @param _handler The address of the new handler
-        @notice Only the handler can call this function
-     */
+	/// @notice Sets the handler of the FungibleTokenWrapper contract
+	/// @param _handler The address of the new handler
+	/// @notice Only the handler can call this function
 	function setHandler(address _handler) public onlyHandler {
 		require(_handler != address(0), "FungibleTokenWrapper: Handler Address can't be 0");
 		handler = _handler;
 		emit HandlerUpdated(_handler);
 	}
 
-	/**
-        @notice Sets whether native tokens are allowed to be wrapped
-        @param _isNativeAllowed Whether or not native tokens are allowed to be wrapped
-        @notice Only the handler can call this function
-     */
+	/// @notice Sets whether native tokens are allowed to be wrapped
+	/// @param _isNativeAllowed Whether or not native tokens are allowed to be wrapped
+	/// @notice Only the handler can call this function
 	function setNativeAllowed(bool _isNativeAllowed) public onlyHandler {
 		isNativeAllowed = _isNativeAllowed;
 	}
 
-	/**
-        @notice Adds a token at `_tokenAddress` to the FungibleTokenWrapper's wrapping list
-        @param _tokenAddress The address of the token to be added
-        @param _nonce The nonce tracking updates to this contract
-        @notice Only the handler can call this function
-     */
+	/// @notice Adds a token at `_tokenAddress` to the FungibleTokenWrapper's wrapping list
+	/// @param _tokenAddress The address of the token to be added
+	/// @param _nonce The nonce tracking updates to this contract
+	/// @notice Only the handler can call this function
 	function add(
 		address _tokenAddress,
 		uint32 _nonce
@@ -114,12 +102,10 @@ contract FungibleTokenWrapper is
 		valid[_tokenAddress] = true;
 	}
 
-	/**
-        @notice Removes a token at `_tokenAddress` from the FungibleTokenWrapper's wrapping list
-        @param _tokenAddress The address of the token to be removed
-        @param _nonce The nonce tracking updates to this contract
-        @notice Only the handler can call this function
-     */
+	/// @notice Removes a token at `_tokenAddress` from the FungibleTokenWrapper's wrapping list
+	/// @param _tokenAddress The address of the token to be removed
+	/// @param _nonce The nonce tracking updates to this contract
+	/// @notice Only the handler can call this function
 	function remove(
 		address _tokenAddress,
 		uint32 _nonce
@@ -137,12 +123,10 @@ contract FungibleTokenWrapper is
 		removeTokenAtIndex(index);
 	}
 
-	/**
-        @notice Sets a new `_feePercentage` for the FungibleTokenWrapper
-        @param _feePercentage The new fee percentage
-        @param _nonce The nonce tracking updates to this contract
-        @notice Only the handler can call this function
-     */
+	/// @notice Sets a new `_feePercentage` for the FungibleTokenWrapper
+	/// @param _feePercentage The new fee percentage
+	/// @param _nonce The nonce tracking updates to this contract
+	/// @notice Only the handler can call this function
 	function setFee(
 		uint16 _feePercentage,
 		uint32 _nonce
@@ -151,12 +135,10 @@ contract FungibleTokenWrapper is
 		feePercentage = _feePercentage;
 	}
 
-	/**
-        @notice Sets a new `_feeRecipient` for the FungibleTokenWrapper
-        @param _feeRecipient The new fee recipient
-        @param _nonce The nonce tracking updates to this contract
-        @notice Only the handler can call this function
-     */
+	/// @notice Sets a new `_feeRecipient` for the FungibleTokenWrapper
+	/// @param _feeRecipient The new fee recipient
+	/// @param _nonce The nonce tracking updates to this contract
+	/// @notice Only the handler can call this function
 	function setFeeRecipient(
 		address payable _feeRecipient,
 		uint32 _nonce
@@ -168,80 +150,62 @@ contract FungibleTokenWrapper is
 		feeRecipient = _feeRecipient;
 	}
 
-	/**
-        @notice Removes a token at `_index` from the FungibleTokenWrapper's wrapping list
-        @param _index The index of the token to be removed
-     */
+	/// @notice Removes a token at `_index` from the FungibleTokenWrapper's wrapping list
+	/// @param _index The index of the token to be removed
 	function removeTokenAtIndex(uint _index) internal {
 		tokens[_index] = tokens[tokens.length - 1];
 		tokens.pop();
 	}
 
-	/**
-        @notice Updates the `_limit` of tokens that can be wrapped
-        @param _limit The new limit of tokens that can be wrapped
-        @notice Only the handler can call this function
-     */
+	/// @notice Updates the `_limit` of tokens that can be wrapped
+	/// @param _limit The new limit of tokens that can be wrapped
+	/// @notice Only the handler can call this function
 	function updateLimit(uint256 _limit) public onlyHandler {
 		wrappingLimit = _limit;
 	}
 
-	/**
-        @notice Gets the current fee percentage
-        @return uint16 The fee percentage
-     */
+	/// @notice Gets the current fee percentage
+	/// @return uint16 The fee percentage
 	function getFee() external view returns (uint16) {
 		return feePercentage;
 	}
 
-	/**
-        @notice Checks if the token at `tokenAddress` is valid (i.e. if it's in the wrapping list)
-        @return bool Whether or not the token is valid
-     */
+	/// @notice Checks if the token at `tokenAddress` is valid (i.e. if it's in the wrapping list)
+	/// @return bool Whether or not the token is valid
 	function _isValidAddress(address tokenAddress) internal view virtual override returns (bool) {
 		return valid[tokenAddress];
 	}
 
-	/**
-        @notice Checks if the token at `tokenAddress` is historically valid
-        (i.e. if it was in the wrapping list at any point in history).
-        @param _tokenAddress The address of the token to be checked
-        @return bool Whether or not the token is historically valid
-     */
+	/// @notice Checks if the token at `tokenAddress` is historically valid
+	/// (i.e. if it was in the wrapping list at any point in history).
+	/// @param _tokenAddress The address of the token to be checked
+	/// @return bool Whether or not the token is historically valid
 	function _isValidHistoricalAddress(
 		address _tokenAddress
 	) internal view virtual override returns (bool) {
 		return historicallyValid[_tokenAddress];
 	}
 
-	/**
-        @notice Checks if an amount of the underlying token can be wrapped or if the limit has been reached
-        @param _amount The amount of the underlying token to be wrapped
-        @return bool Whether or not the amount can be wrapped
-     */
+	/// @notice Checks if an amount of the underlying token can be wrapped or if the limit has been reached
+	/// @param _amount The amount of the underlying token to be wrapped
+	/// @return bool Whether or not the amount can be wrapped
 	function _isValidAmount(uint256 _amount) internal view virtual override returns (bool) {
 		return _amount + this.totalSupply() <= wrappingLimit;
 	}
 
-	/**
-        @notice Checks if the native token is allowed to be wrapped
-        @return bool Whether or not the native token is allowed to be wrapped
-     */
+	/// @notice Checks if the native token is allowed to be wrapped
+	/// @return bool Whether or not the native token is allowed to be wrapped
 	function _isNativeValid() internal view virtual override returns (bool) {
 		return isNativeAllowed;
 	}
 
-	/**
-        @notice Gets the currently available wrappable tokens by their addresses
-        @return address[] The currently available wrappable token addresses
-     */
+	/// @notice Gets the currently available wrappable tokens by their addresses
+	/// @return address[] The currently available wrappable token addresses
 	function getTokens() external view returns (address[] memory) {
 		return tokens;
 	}
 
-	/**
-        @notice Modifier for enforcing that the caller is the handler
-     */
+	/// @notice Modifier for enforcing that the caller is the handler
 	modifier onlyHandler() {
 		require(msg.sender == handler, "FungibleTokenWrapper: Only handler can call this function");
 		_;

--- a/packages/contracts/contracts/tokens/TokenWrapper.sol
+++ b/packages/contracts/contracts/tokens/TokenWrapper.sol
@@ -12,59 +12,47 @@ import "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetMinterPauser.sol"
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 
-/**
-	@title A token that allows ERC20s to wrap into and mint it.
-	@author Webb Technologies.
-	@notice This contract is intended to be used with TokenHandler/FungibleToken contract.
- */
+/// @title A token that allows ERC20s to wrap into and mint it.
+/// @author Webb Technologies.
+/// @notice This contract is intended to be used with TokenHandler/FungibleToken contract.
 abstract contract TokenWrapper is ERC20PresetMinterPauser, ITokenWrapper, ReentrancyGuard {
 	using SafeERC20 for IERC20;
 	uint16 public feePercentage;
 	address payable public feeRecipient;
 
-	/**
-		@notice TokenWrapper constructor
-		@param _name The name of the ERC20
-		@param _symbol The symbol of the ERC20
-	 */
+	/// @notice TokenWrapper constructor
+	/// @param _name The name of the ERC20
+	/// @param _symbol The symbol of the ERC20
 	constructor(
 		string memory _name,
 		string memory _symbol
 	) ERC20PresetMinterPauser(_name, _symbol) {}
 
-	/**
-		@notice Get the fee for a target amount to wrap
-		@param _amountToWrap The amount to wrap
-		@return uint The fee amount of the token being wrapped
-	 */
+	/// @notice Get the fee for a target amount to wrap
+	/// @param _amountToWrap The amount to wrap
+	/// @return uint The fee amount of the token being wrapped
 	function getFeeFromAmount(uint256 _amountToWrap) public view override returns (uint256) {
 		return (_amountToWrap * feePercentage) / 10000;
 	}
 
-	/**
-		@notice Get the fee for a target amount to wrap
-		@param _admin the address for granting minting, pausing and admin roles at initialization
-	 */
+	/// @notice Get the fee for a target amount to wrap
+	/// @param _admin the address for granting minting, pausing and admin roles at initialization
 	function _initialize(address _admin) internal {
 		_setupRole(MINTER_ROLE, _admin);
 		_setupRole(DEFAULT_ADMIN_ROLE, _admin);
 		_setupRole(PAUSER_ROLE, _admin);
 	}
 
-	/**
-		@notice Get the amount to wrap for a target `_deposit` amount
-		@param _deposit The deposit amount
-		@return uint The amount to wrap conditioned on the deposit amount
-	 */
+	/// @notice Get the amount to wrap for a target `_deposit` amount
+	/// @param _deposit The deposit amount
+	/// @return uint The amount to wrap conditioned on the deposit amount
 	function getAmountToWrap(uint256 _deposit) public view override returns (uint256) {
 		return (_deposit * 10000) / (10000 - feePercentage);
 	}
 
-	/**
-		@notice Used to wrap tokens on behalf of a sender. Must be called by a minter role.
-		@param tokenAddress Address of ERC20 to transfer.
-		@param amount Amount of tokens to transfer.
-	 */
+	/// @notice Used to wrap tokens on behalf of a sender. Must be called by a minter role.
+	/// @param tokenAddress Address of ERC20 to transfer.
+	/// @param amount Amount of tokens to transfer.
 	function wrap(
 		address tokenAddress,
 		uint256 amount
@@ -72,12 +60,10 @@ abstract contract TokenWrapper is ERC20PresetMinterPauser, ITokenWrapper, Reentr
 		_wrapForAndSendTo(_msgSender(), tokenAddress, amount, _msgSender());
 	}
 
-	/**
-		@notice Used to wrap tokens on behalf of a sender
-		@param sender Address of sender where assets are sent from.
-		@param tokenAddress Address of ERC20 to transfer.
-		@param amount Amount of tokens to transfer.
-	 */
+	/// @notice Used to wrap tokens on behalf of a sender
+	/// @param sender Address of sender where assets are sent from.
+	/// @param tokenAddress Address of ERC20 to transfer.
+	/// @param amount Amount of tokens to transfer.
 	function wrapFor(
 		address sender,
 		address tokenAddress,
@@ -93,13 +79,11 @@ abstract contract TokenWrapper is ERC20PresetMinterPauser, ITokenWrapper, Reentr
 		_wrapForAndSendTo(sender, tokenAddress, amount, sender);
 	}
 
-	/**
-		@notice Used to wrap tokens on behalf of a sender and mint to a potentially different address
-		@param sender Address of sender where assets are sent from.
-		@param tokenAddress Address of ERC20 to transfer.
-		@param amount Amount of tokens to transfer.
-		@param recipient Recipient of the wrapped tokens.
-	 */
+	/// @notice Used to wrap tokens on behalf of a sender and mint to a potentially different address
+	/// @param sender Address of sender where assets are sent from.
+	/// @param tokenAddress Address of ERC20 to transfer.
+	/// @param amount Amount of tokens to transfer.
+	/// @param recipient Recipient of the wrapped tokens.
 	function wrapForAndSendTo(
 		address sender,
 		address tokenAddress,
@@ -116,11 +100,9 @@ abstract contract TokenWrapper is ERC20PresetMinterPauser, ITokenWrapper, Reentr
 		_wrapForAndSendTo(sender, tokenAddress, amount, recipient);
 	}
 
-	/**
-		@notice Used to unwrap/burn the wrapper token on behalf of a sender.
-		@param tokenAddress Address of ERC20 to unwrap into.
-		@param amount Amount of tokens to burn.
-	 */
+	/// @notice Used to unwrap/burn the wrapper token on behalf of a sender.
+	/// @param tokenAddress Address of ERC20 to unwrap into.
+	/// @param amount Amount of tokens to burn.
 	function unwrap(
 		address tokenAddress,
 		uint256 amount
@@ -128,11 +110,9 @@ abstract contract TokenWrapper is ERC20PresetMinterPauser, ITokenWrapper, Reentr
 		_unwrapAndSendTo(_msgSender(), tokenAddress, amount, _msgSender());
 	}
 
-	/**
-		@notice Used to unwrap/burn the wrapper token on behalf of a sender.
-		@param tokenAddress Address of ERC20 to unwrap into.
-		@param amount Amount of tokens to burn.
-	 */
+	/// @notice Used to unwrap/burn the wrapper token on behalf of a sender.
+	/// @param tokenAddress Address of ERC20 to unwrap into.
+	/// @param amount Amount of tokens to burn.
 	function unwrapAndSendTo(
 		address tokenAddress,
 		uint256 amount,
@@ -141,12 +121,10 @@ abstract contract TokenWrapper is ERC20PresetMinterPauser, ITokenWrapper, Reentr
 		_unwrapAndSendTo(_msgSender(), tokenAddress, amount, recipient);
 	}
 
-	/**
-		@notice Used to unwrap/burn the wrapper token.
-		@param sender The address that the caller is unwrapping for
-		@param tokenAddress Address of ERC20 to unwrap into.
-		@param amount Amount of tokens to burn.
-	 */
+	/// @notice Used to unwrap/burn the wrapper token.
+	/// @param sender The address that the caller is unwrapping for
+	/// @param tokenAddress Address of ERC20 to unwrap into.
+	/// @param amount Amount of tokens to burn.
 	function unwrapFor(
 		address sender,
 		address tokenAddress,
@@ -203,17 +181,13 @@ abstract contract TokenWrapper is ERC20PresetMinterPauser, ITokenWrapper, Reentr
 			IERC20(tokenAddress).safeTransfer(recipient, amount);
 		}
 	}
-
-	/** @dev this function is defined in a child contract */
+ 	/// @dev this function is defined in a child contract
 	function _isValidAddress(address tokenAddress) internal view virtual returns (bool);
-
-	/** @dev this function is defined in a child contract */
+ 	/// @dev this function is defined in a child contract
 	function _isValidHistoricalAddress(address tokenAddress) internal view virtual returns (bool);
-
-	/** @dev this function is defined in a child contract */
+ 	/// @dev this function is defined in a child contract
 	function _isNativeValid() internal view virtual returns (bool);
-
-	/** @dev this function is defined in a child contract */
+ 	/// @dev this function is defined in a child contract
 	function _isValidAmount(uint256 amount) internal view virtual returns (bool);
 
 	modifier isMinter() {
@@ -221,12 +195,10 @@ abstract contract TokenWrapper is ERC20PresetMinterPauser, ITokenWrapper, Reentr
 		_;
 	}
 
-	/**
-		@notice Modifier to check if the wrapping is valid
-		@param _tokenAddress The token address to wrap from
-		@param _feeRecipient The fee recipient for the wrapping fee
-		@param _amount The amount of tokens to wrap
-	 */
+	/// @notice Modifier to check if the wrapping is valid
+	/// @param _tokenAddress The token address to wrap from
+	/// @param _feeRecipient The fee recipient for the wrapping fee
+	/// @param _amount The amount of tokens to wrap
 	modifier isValidWrapping(
 		address _tokenAddress,
 		address _feeRecipient,
@@ -248,11 +220,9 @@ abstract contract TokenWrapper is ERC20PresetMinterPauser, ITokenWrapper, Reentr
 		_;
 	}
 
-	/**
-		@notice Modifier to check if the unwrapping is valid
-		@param _tokenAddress The token address to unwrap into
-		@param _amount The amount of tokens to unwrap
-	 */
+	/// @notice Modifier to check if the unwrapping is valid
+	/// @param _tokenAddress The token address to unwrap into
+	/// @param _amount The amount of tokens to unwrap
 	modifier isValidUnwrapping(address _tokenAddress, uint256 _amount) {
 		if (_tokenAddress == address(0)) {
 			require(address(this).balance >= _amount, "TokenWrapper: Insufficient native balance");

--- a/packages/contracts/contracts/tokens/TokenWrapper.sol
+++ b/packages/contracts/contracts/tokens/TokenWrapper.sol
@@ -181,13 +181,17 @@ abstract contract TokenWrapper is ERC20PresetMinterPauser, ITokenWrapper, Reentr
 			IERC20(tokenAddress).safeTransfer(recipient, amount);
 		}
 	}
- 	/// @dev this function is defined in a child contract
+
+	/// @dev this function is defined in a child contract
 	function _isValidAddress(address tokenAddress) internal view virtual returns (bool);
- 	/// @dev this function is defined in a child contract
+
+	/// @dev this function is defined in a child contract
 	function _isValidHistoricalAddress(address tokenAddress) internal view virtual returns (bool);
- 	/// @dev this function is defined in a child contract
+
+	/// @dev this function is defined in a child contract
 	function _isNativeValid() internal view virtual returns (bool);
- 	/// @dev this function is defined in a child contract
+
+	/// @dev this function is defined in a child contract
 	function _isValidAmount(uint256 amount) internal view virtual returns (bool);
 
 	modifier isMinter() {

--- a/packages/contracts/contracts/trees/LinkableIncrementalBinaryTree.sol
+++ b/packages/contracts/contracts/trees/LinkableIncrementalBinaryTree.sol
@@ -244,9 +244,7 @@ library LinkableIncrementalBinaryTree {
 		return hash == uint256(self.roots[self.currentRootIndex]);
 	}
 
-	/**
-		@dev Whether the root is present in the root history
-	*/
+	/// @dev Whether the root is present in the root history
 	function isKnownRoot(
 		LinkableIncrementalTreeData storage self,
 		uint256 _root
@@ -269,17 +267,13 @@ library LinkableIncrementalBinaryTree {
 		return false;
 	}
 
-	/**
-		@dev Returns the last root
-	*/
+	/// @dev Returns the last root
 	function getLastRoot(LinkableIncrementalTreeData storage self) public view returns (uint256) {
 		return self.roots[self.currentRootIndex];
 	}
 
-	/**
-		@notice Decodes a byte string of roots into its parts.
-		@return bytes32[] An array of bytes32 merkle roots
-	 */
+	/// @notice Decodes a byte string of roots into its parts.
+	/// @return bytes32[] An array of bytes32 merkle roots
 	function decodeRoots(
 		LinkableIncrementalTreeData storage self,
 		bytes calldata roots
@@ -292,9 +286,7 @@ library LinkableIncrementalBinaryTree {
 		return decodedRoots;
 	}
 
-	/**
-		Parses the typed chain ID out from a 32-byte resource ID
-	 */
+	/// Parses the typed chain ID out from a 32-byte resource ID
 	function parseChainIdFromResourceId(bytes32 _resourceId) public pure returns (uint64) {
 		return uint64(uint48(bytes6(_resourceId << (26 * 8))));
 	}

--- a/packages/contracts/contracts/trees/LinkableIncrementalBinaryTree.sol
+++ b/packages/contracts/contracts/trees/LinkableIncrementalBinaryTree.sol
@@ -2,6 +2,7 @@
  * Copyright 2021-2023 Webb Technologies
  * SPDX-License-Identifier: MIT OR Apache-2.0
  */
+
 pragma solidity ^0.8.4;
 
 import { PoseidonT3 } from "../hashers/Poseidon.sol";
@@ -244,8 +245,8 @@ library LinkableIncrementalBinaryTree {
 	}
 
 	/**
-        @dev Whether the root is present in the root history
-    */
+		@dev Whether the root is present in the root history
+	*/
 	function isKnownRoot(
 		LinkableIncrementalTreeData storage self,
 		uint256 _root
@@ -269,16 +270,16 @@ library LinkableIncrementalBinaryTree {
 	}
 
 	/**
-        @dev Returns the last root
-    */
+		@dev Returns the last root
+	*/
 	function getLastRoot(LinkableIncrementalTreeData storage self) public view returns (uint256) {
 		return self.roots[self.currentRootIndex];
 	}
 
 	/**
-        @notice Decodes a byte string of roots into its parts.
-        @return bytes32[] An array of bytes32 merkle roots
-     */
+		@notice Decodes a byte string of roots into its parts.
+		@return bytes32[] An array of bytes32 merkle roots
+	 */
 	function decodeRoots(
 		LinkableIncrementalTreeData storage self,
 		bytes calldata roots
@@ -292,8 +293,8 @@ library LinkableIncrementalBinaryTree {
 	}
 
 	/**
-        Parses the typed chain ID out from a 32-byte resource ID
-     */
+		Parses the typed chain ID out from a 32-byte resource ID
+	 */
 	function parseChainIdFromResourceId(bytes32 _resourceId) public pure returns (uint64) {
 		return uint64(uint48(bytes6(_resourceId << (26 * 8))));
 	}

--- a/packages/contracts/contracts/trees/MerkleForest.sol
+++ b/packages/contracts/contracts/trees/MerkleForest.sol
@@ -9,6 +9,9 @@ import "./LinkableIncrementalBinaryTree.sol";
 import "../interfaces/IMerkleSystem.sol";
 import "../hashers/IHasher.sol";
 
+/// @title MerkleForest contract that stores multiple merkle trees in a forest.
+/// @author Webb Technologies.
+/// @notice This contract is meant to be used to store multiple merkle trees in a forest.
 contract MerkleForest is MerkleSystem {
 	using LinkableIncrementalBinaryTree for LinkableIncrementalTreeData;
 	IHasher public hasher;
@@ -22,7 +25,10 @@ contract MerkleForest is MerkleSystem {
 	mapping(uint256 => LinkableIncrementalTreeData) public subtrees;
 	LinkableIncrementalTreeData public merkleForest;
 
-	// bytes32[] public leaves;
+	/// @notice Initializes the MerkleForest contract.
+	/// @param _forestLevels The number of levels in the forest.
+	/// @param _subtreeLevels The number of levels in each subtree.
+	/// @param _hasher The address of the hasher contract.
 	constructor(uint32 _forestLevels, uint32 _subtreeLevels, IHasher _hasher) {
 		require(_forestLevels > 0, "_forestLevels should be greater than zero");
 		require(_subtreeLevels > 0, "_subtreeLevels should be greater than zero");
@@ -41,9 +47,7 @@ contract MerkleForest is MerkleSystem {
 		subtreeLevels = _subtreeLevels;
 	}
 
-	/**
-        @dev inserts single leaf into subtree then update forest
-    */
+	/// @dev inserts single leaf into subtree then update forest
 	function _insert(uint256 _leaf) internal override returns (uint32) {
 		if (numSubtreeElements >= uint32(2 ** subtreeLevels)) {
 			numSubtreeElements = 0;
@@ -56,9 +60,7 @@ contract MerkleForest is MerkleSystem {
 		return numSubtreeElements;
 	}
 
-	/**
-        @dev inserts pair of leaves into subtree then update forest
-    */
+	/// @dev inserts pair of leaves into subtree then update forest
 	function _insertTwo(uint256 _leaf1, uint256 _leaf2) internal override returns (uint32) {
 		if (numSubtreeElements + 1 >= uint32(2 ** subtreeLevels)) {
 			numSubtreeElements = 0;
@@ -71,9 +73,7 @@ contract MerkleForest is MerkleSystem {
 		return index;
 	}
 
-	/**
-        @dev inserts single leaf into specific subtreeId (if possible)
-    */
+	/// @dev inserts single leaf into specific subtreeId (if possible)
 	function _insertSubtree(uint32 _subtreeId, uint256 _leaf) internal returns (uint) {
 		if (numSubtreeElements >= uint32(2 ** subtreeLevels)) {
 			numSubtreeElements = 0;
@@ -85,16 +85,12 @@ contract MerkleForest is MerkleSystem {
 		return merkleForest.getLastRoot();
 	}
 
-	/**
-        @dev Whether the root is present in any of the subtree's history
-    */
+	/// @dev Whether the root is present in any of the subtree's history
 	function isKnownSubtreeRoot(uint _subtreeId, uint256 _root) public view returns (bool) {
 		return subtrees[_subtreeId].isKnownRoot(uint(_root));
 	}
 
-	/**
-        @dev Whether the root is present in any of the subtree's history
-    */
+	/// @dev Whether the root is present in any of the subtree's history
 	function getLastSubtreeRoot(uint256 _subtreeId) public view returns (uint) {
 		return subtrees[_subtreeId].getLastRoot();
 	}

--- a/packages/contracts/contracts/trees/MerkleTree.sol
+++ b/packages/contracts/contracts/trees/MerkleTree.sol
@@ -7,6 +7,9 @@ pragma solidity ^0.8.18;
 
 import "./MerkleTreeWithHistory.sol";
 
+/// @title MerkleTree contract.
+/// @author Webb Technologies.
+/// @notice This contract is used to store the merkle tree data.
 contract MerkleTree is MerkleTreeWithHistory {
 	constructor(uint32 _levels, IHasher _hasher) {
 		require(_levels > 0, "_levels should be greater than zero");

--- a/packages/contracts/contracts/trees/MerkleTreeWithHistory.sol
+++ b/packages/contracts/contracts/trees/MerkleTreeWithHistory.sol
@@ -8,6 +8,9 @@ pragma solidity ^0.8.18;
 import "../hashers/IHasher.sol";
 import "../interfaces/IMerkleSystem.sol";
 
+/// @title MerkleTreeWithHistory contract stores history of roots.
+/// @author Webb Technologies.
+/// @notice This contract is used to store the merkle tree data.
 abstract contract MerkleTreeWithHistory is MerkleSystem {
 	uint32 public currentRootIndex = 0;
 	uint32 public nextIndex = 0;

--- a/packages/contracts/contracts/utils/ChainIdWithType.sol
+++ b/packages/contracts/contracts/utils/ChainIdWithType.sol
@@ -5,15 +5,11 @@
 
 pragma solidity ^0.8.18;
 
-/**
-    @title ChainIdWithType abstract contract
- */
+/// @title ChainIdWithType abstract contract
 abstract contract ChainIdWithType {
 	bytes2 public constant EVM_CHAIN_ID_TYPE = 0x0100;
 
-	/**
-        @notice Gets the chain id using the chain id opcode
-     */
+	/// @notice Gets the chain id using the chain id opcode
 	function getChainId() public view returns (uint) {
 		uint chainId;
 		assembly {
@@ -22,9 +18,7 @@ abstract contract ChainIdWithType {
 		return chainId;
 	}
 
-	/**
-        @notice Computes the modified chain id using the underlying chain type (EVM)
-     */
+	/// @notice Computes the modified chain id using the underlying chain type (EVM)
 	function getChainIdType() public view returns (uint48) {
 		// The chain ID and type pair is 6 bytes in length
 		// The first 2 bytes are reserved for the chain type.
@@ -38,27 +32,21 @@ abstract contract ChainIdWithType {
 		return uint48(bytes6(chainIdWithType));
 	}
 
-	/**
-        Parses the typed chain ID out from a 32-byte resource ID
-     */
+	/// @notice Parses the typed chain ID out from a 32-byte resource ID
 	function parseChainIdFromResourceId(bytes32 _resourceId) public pure returns (uint64) {
 		return uint64(uint48(bytes6(_resourceId << (26 * 8))));
 	}
 
-	/**
-		@notice Verifies that the current chain matches the chain ID from the resource ID
-		@param resourceID The resource ID to verify
-	 */
+	/// @notice Verifies that the current chain matches the chain ID from the resource ID
+	/// @param resourceID The resource ID to verify
 	function isCorrectExecutionChain(bytes32 resourceID) external view returns (bool) {
 		uint64 executionChainId = parseChainIdFromResourceId(resourceID);
 		// Verify current chain matches chain ID from resource ID
 		return uint256(getChainIdType()) == uint256(executionChainId);
 	}
 
-	/**
-		@notice Verifies that the current execution context matches the execution context from the resource ID
-		@param resourceId The resource ID to verify
-	 */
+	/// @notice Verifies that the current execution context matches the execution context from the resource ID
+	/// @param resourceId The resource ID to verify
 	function isCorrectExecutionContext(bytes32 resourceId) public view returns (bool) {
 		return address(bytes20(resourceId << (6 * 8))) == address(this);
 	}

--- a/packages/contracts/contracts/utils/Governable.sol
+++ b/packages/contracts/contracts/utils/Governable.sol
@@ -22,7 +22,7 @@ contract Governable {
 	/// -------------------------------------------------------
 	/// Storage values relevant to proposer set update
 	/// -------------------------------------------------------
-	
+
 	/// The proposal nonce
 	uint32 public proposerSetUpdateNonce = 0;
 	/// The root of the proposer set Merkle tree
@@ -212,7 +212,7 @@ contract Governable {
 
 	/// @notice Casts a vote in favor of force refreshing the governor
 	/// @param vote A vote struct
-	function voteInFavorForceSetGovernor(Vote memory vote) isValidTimeToVote external {
+	function voteInFavorForceSetGovernor(Vote memory vote) external isValidTimeToVote {
 		address proposerAddress = msg.sender;
 		// Check merkle proof is valid
 		require(
@@ -231,7 +231,10 @@ contract Governable {
 	/// @notice Casts a vote in favor of force refreshing the governor with a signature
 	/// @param votes Vote structs
 	/// @param sig Signatures of the votes
-	function voteInFavorForceSetGovernorWithSig(Vote[] memory votes, bytes[] memory sigs) isValidTimeToVote external {
+	function voteInFavorForceSetGovernorWithSig(
+		Vote[] memory votes,
+		bytes[] memory sigs
+	) external isValidTimeToVote {
 		require(votes.length == sigs.length, "Governable: Invalid number of votes and signatures");
 		for (uint i = 0; i < votes.length; i++) {
 			// Recover the public key from the signature
@@ -250,7 +253,7 @@ contract Governable {
 			}
 		}
 
-		_tryResolveVote(vote.proposedGovernor);	
+		_tryResolveVote(vote.proposedGovernor);
 	}
 
 	/// @notice Tries and resolves the vote by checking the number of votes for

--- a/packages/contracts/contracts/utils/Initialized.sol
+++ b/packages/contracts/contracts/utils/Initialized.sol
@@ -5,10 +5,9 @@
 
 pragma solidity ^0.8.18;
 
-/**
-    @title A contract that can be initialized once and only once
-    @author Webb Technologies.
- */
+/// @title A contract that can be initialized once and only once
+/// @author Webb Technologies.
+/// @notice This contract is used to ensure that a contract can only be initialized once.
 contract Initialized {
 	bool public initialized;
 

--- a/packages/contracts/contracts/utils/ProofUtils.sol
+++ b/packages/contracts/contracts/utils/ProofUtils.sol
@@ -5,13 +5,14 @@
 
 pragma solidity ^0.8.18;
 
+/// @title ProofUtils contract.
+/// @author Webb Technologies.
+/// @notice This contract is used to unpack the proof values.
 contract ProofUtils {
-	/**
-        @notice A helper function to convert an array of 8 uint256 values into the a, b,
-        and c array values that the zk-SNARK verifier's verifyProof accepts.
-        @param _proof The array of 8 uint256 values
-        @return (uint256[2] memory a, uint256[2][2] memory b, uint256[2] memory c) The unpacked proof values
-    */
+	/// @notice A helper function to convert an array of 8 uint256 values into the a, b,
+	/// and c array values that the zk-SNARK verifier's verifyProof accepts.
+	/// @param _proof The array of 8 uint256 values
+	/// @return (uint256[2] memory a, uint256[2][2] memory b, uint256[2] memory c) The unpacked proof values
 	function unpackProof(
 		uint256[8] memory _proof
 	) public pure returns (uint256[2] memory, uint256[2][2] memory, uint256[2] memory) {

--- a/packages/contracts/contracts/utils/ProposalNonceTracker.sol
+++ b/packages/contracts/contracts/utils/ProposalNonceTracker.sol
@@ -5,10 +5,9 @@
 
 pragma solidity ^0.8.18;
 
-/**
-    @title A contract that can be initialized once and only once
-    @author Webb Technologies.
- */
+/// @title A contract that can be initialized once and only once
+/// @author Webb Technologies.
+/// @notice This contract tracks nonces for proposal execution.
 contract ProposalNonceTracker {
 	uint256 public proposalNonce;
 

--- a/packages/contracts/contracts/vanchors/base/LinkableAnchor.sol
+++ b/packages/contracts/contracts/vanchors/base/LinkableAnchor.sol
@@ -13,32 +13,30 @@ import "../../utils/ProposalNonceTracker.sol";
 import "../../interfaces/ILinkableAnchor.sol";
 import "../../interfaces/IMerkleSystem.sol";
 
-/**
-    @title The LinkableAnchor contract
-    @author Webb Technologies
-    @notice The LinkableAnchor contract extends the MerkleTreePoseidon contract
-    with a graph-like interface for linking to other LinkableAnchors. Links
-    between these trees are represented as directed edges (since updates occur
-    on one contract per transaction). The edge data is maintained as a record of the:
-    - Chain id that the edge points to
-    - Latest merkle root of the MerkleTreePoseidon contract being linked
-    - Latest leaf insertion index (used as a nonce) of the linked merkle tree.
-
-    Updating the state of the LinkableAnchor's edges is done through the handler
-    architecture defined originally by ChainSafe's ChainBridge system. In our case,
-    we employ a handler to propagate updates to a LinkableAnchor contract. For example,
-    the handler can be connected to an oracle system, signature system, or any other
-    bridge system to provide the state of the neighboring LinkableAnchor's edge data.
-
-    The LinkableAnchor contract is meant to be inherited by child contracts that
-    define their own architecture around:
-    1. The structure of elements being inserted into the underlying Merkle Tree
-    2. The type of zkSNARK necessary for proving membership of a specific element
-       in one-of-many LinkableAnchors connected in a bridge.
-
-    An example usage of this system is the:
-    - VAnchor.sol - for variable sized private bridging of assets
- */
+/// @title The LinkableAnchor contract
+/// @author Webb Technologies
+/// @notice The LinkableAnchor contract extends the MerkleTreePoseidon contract
+/// with a graph-like interface for linking to other LinkableAnchors. Links
+/// between these trees are represented as directed edges (since updates occur
+/// on one contract per transaction). The edge data is maintained as a record of the:
+/// - Chain id that the edge points to
+/// - Latest merkle root of the MerkleTreePoseidon contract being linked
+/// - Latest leaf insertion index (used as a nonce) of the linked merkle tree.
+/// 
+/// Updating the state of the LinkableAnchor's edges is done through the handler
+/// architecture defined originally by ChainSafe's ChainBridge system. In our case,
+/// we employ a handler to propagate updates to a LinkableAnchor contract. For example,
+/// the handler can be connected to an oracle system, signature system, or any other
+/// bridge system to provide the state of the neighboring LinkableAnchor's edge data.
+///
+/// The LinkableAnchor contract is meant to be inherited by child contracts that
+/// define their own architecture around:
+/// 1. The structure of elements being inserted into the underlying Merkle Tree
+/// 2. The type of zkSNARK necessary for proving membership of a specific element
+///    in one-of-many LinkableAnchors connected in a bridge.
+///
+/// An example usage of this system is the:
+/// - VAnchor.sol - for variable sized private bridging of assets
 abstract contract LinkableAnchor is
 	ILinkableAnchor,
 	MerkleSystem,
@@ -48,50 +46,44 @@ abstract contract LinkableAnchor is
 {
 	address public handler;
 
-	// The maximum number of edges this tree can support for zero-knowledge linkability.
+	/// The maximum number of edges this tree can support for zero-knowledge linkability.
 	uint8 public immutable maxEdges;
 	uint32 public immutable outerLevels;
 
-	// Maps sourceChainID to the index in the edge list
+	/// Maps sourceChainID to the index in the edge list
 	mapping(uint256 => uint256) public edgeIndex;
 	mapping(uint256 => bool) public edgeExistsForChain;
 	Edge[] public edgeList;
 
-	// Map to store chainID => (rootIndex => root) to track neighbor histories
+	/// Map to store chainID => (rootIndex => root) to track neighbor histories
 	mapping(uint256 => mapping(uint32 => uint256)) public neighborRoots;
-	// Map to store the current historical root index for a chainID
+	/// Map to store the current historical root index for a chainID
 	mapping(uint256 => uint32) public currentNeighborRootIndex;
 
-	// Edge linking events
+	/// Edge linking events
 	event EdgeAddition(uint256 chainID, uint256 latestLeafIndex, uint256 merkleRoot);
 	event EdgeUpdate(uint256 chainID, uint256 latestLeafIndex, uint256 merkleRoot);
 
-	/**
-        @notice Checks the sender is the AnchorHandler configured on this contract
-     */
+	/// @notice Checks the sender is the AnchorHandler configured on this contract
 	modifier onlyHandler() {
 		require(msg.sender == handler, "sender is not the handler");
 		_;
 	}
 
-	/**
-        @notice The LinkableAnchor constructor
-        @param _handler The address of the `AnchorHandler` contract
-        @param _outerTreeHeight The height of outer-most merkle tree
-        @param _maxEdges The maximum # of edges this linkable tree connects to
-    */
+	/// @notice The LinkableAnchor constructor
+	/// @param _handler The address of the `AnchorHandler` contract
+	/// @param _outerTreeHeight The height of outer-most merkle tree
+	/// @param _maxEdges The maximum # of edges this linkable tree connects to
 	constructor(address _handler, uint32 _outerTreeHeight, uint8 _maxEdges) {
 		handler = _handler;
 		outerLevels = _outerTreeHeight;
 		maxEdges = _maxEdges;
 	}
 
-	/**
-        @notice Add an edge to the tree or update an existing edge.
-        @param _root The merkle root of the edge's merkle tree
-        @param _leafIndex The latest leaf insertion index of the edge's merkle tree
-        @param _srcResourceID The origin resource ID of the originating linked anchor update
-     */
+	/// @notice Add an edge to the tree or update an existing edge.
+	/// @param _root The merkle root of the edge's merkle tree
+	/// @param _leafIndex The latest leaf insertion index of the edge's merkle tree
+	/// @param _srcResourceID The origin resource ID of the originating linked anchor update
 	function updateEdge(
 		uint256 _root,
 		uint32 _leafIndex,
@@ -143,10 +135,8 @@ abstract contract LinkableAnchor is
 		}
 	}
 
-	/**
-        @notice Get the latest state of all neighbor edges
-        @return Edge[] An array of all neighboring and potentially empty edges
-        */
+	/// @notice Get the latest state of all neighbor edges
+	/// @return Edge[] An array of all neighboring and potentially empty edges
 	function getLatestNeighborEdges() public view returns (Edge[] memory) {
 		Edge[] memory edges = new Edge[](maxEdges);
 		for (uint256 i = 0; i < maxEdges; i++) {
@@ -166,10 +156,8 @@ abstract contract LinkableAnchor is
 		return edges;
 	}
 
-	/**
-        @notice Get the latest merkle roots of all neighbor edges
-        @return bytes32[] An array of merkle roots
-     */
+	/// @notice Get the latest merkle roots of all neighbor edges
+	/// @return bytes32[] An array of merkle roots
 	function getLatestNeighborRoots() public view returns (uint256[] memory) {
 		uint256[] memory roots = new uint256[](maxEdges);
 		for (uint256 i = 0; i < maxEdges; i++) {
@@ -184,11 +172,9 @@ abstract contract LinkableAnchor is
 		return roots;
 	}
 
-	/**
-        @notice Checks to see whether a `_root` is known for a neighboring `neighborChainID`
-        @param _neighborChainID The chainID of the neighbor's edge
-        @param _root The root to check
-     */
+	/// @notice Checks to see whether a `_root` is known for a neighboring `neighborChainID`
+	/// @param _neighborChainID The chainID of the neighbor's edge
+	/// @param _root The root to check
 	function isKnownNeighborRoot(
 		uint256 _neighborChainID,
 		uint256 _root
@@ -210,12 +196,10 @@ abstract contract LinkableAnchor is
 		return false;
 	}
 
-	/**
-        @notice Checks validity of an array of merkle roots in the history.
-        The first root should always be the root of `this` underlying merkle
-        tree and the remaining roots are of the neighboring roots in `edges.
-        @param _roots An array of uint256 merkle roots to be checked against the history.
-     */
+	/// @notice Checks validity of an array of merkle roots in the history.
+	/// The first root should always be the root of `this` underlying merkle
+	/// tree and the remaining roots are of the neighboring roots in `edges.
+	/// @param _roots An array of uint256 merkle roots to be checked against the history.
 	function isValidRoots(uint256[] memory _roots) public view returns (bool) {
 		require(this.isKnownRoot(_roots[0]), "Cannot find your merkle root");
 		require(_roots.length == maxEdges + 1, "Incorrect root array length");
@@ -235,17 +219,13 @@ abstract contract LinkableAnchor is
 		return true;
 	}
 
-	/**
-        @notice Checks the `_chainID` has an edge on this contract
-     */
+	/// @notice Checks the `_chainID` has an edge on this contract
 	function hasEdge(uint256 _chainID) external view returns (bool) {
 		return edgeExistsForChain[_chainID];
 	}
 
-	/**
-        @notice Decodes a byte string of roots into its parts.
-        @return bytes32[] An array of bytes32 merkle roots
-     */
+	/// @notice Decodes a byte string of roots into its parts.
+	/// @return bytes32[] An array of bytes32 merkle roots
 	function decodeRoots(bytes calldata roots) internal view returns (bytes32[] memory) {
 		bytes32[] memory decodedRoots = new bytes32[](maxEdges + 1);
 		for (uint i = 0; i <= maxEdges; i++) {

--- a/packages/contracts/contracts/vanchors/base/LinkableAnchor.sol
+++ b/packages/contracts/contracts/vanchors/base/LinkableAnchor.sol
@@ -22,7 +22,7 @@ import "../../interfaces/IMerkleSystem.sol";
 /// - Chain id that the edge points to
 /// - Latest merkle root of the MerkleTreePoseidon contract being linked
 /// - Latest leaf insertion index (used as a nonce) of the linked merkle tree.
-/// 
+///
 /// Updating the state of the LinkableAnchor's edges is done through the handler
 /// architecture defined originally by ChainSafe's ChainBridge system. In our case,
 /// we employ a handler to propagate updates to a LinkableAnchor contract. For example,

--- a/packages/contracts/contracts/vanchors/base/VAnchor.sol
+++ b/packages/contracts/contracts/vanchors/base/VAnchor.sol
@@ -9,43 +9,41 @@ import "./ZKVAnchorBase.sol";
 import "../../structs/SingleAssetExtData.sol";
 import "../../libs/VAnchorEncodeInputs.sol";
 
-/**
-	@title Variable Anchor contract
-	@author Webb Technologies
-	@notice The Variable Anchor is a variable-denominated shielded pool system
-	derived from Tornado Nova (tornado-pool). This system extends the shielded
-	pool system into a bridged system and allows for join/split transactions.
-
-	The system is built on top the VAnchorBase/AnchorBase/LinkableAnchor system which allows
-	it to be linked to other VAnchor contracts through a simple graph-like
-	interface where anchors maintain edges of their neighboring anchors.
-
-	The system requires users to create and deposit UTXOs for the supported ERC20
-	asset into the smart contract and insert a commitment into the underlying
-	merkle tree of the form: commitment = Poseidon(chainID, amount, pubKey, blinding).
-	The hash input is the UTXO data. All deposits/withdrawals are unified under
-	a common `transact` function which requires a zkSNARK proof that the UTXO commitments
-	are well-formed (i.e. that the deposit amount matches the sum of new UTXOs' amounts).
-	
-	Information regarding the commitments:
-	- Poseidon is a zkSNARK friendly hash function
-	- destinationChainID is the chainId of the destination chain, where the withdrawal
-	  is intended to be made
-	- Details of the UTXO and hashes are below
-
-	UTXO = { destinationChainID, amount, pubkey, blinding }
-	commitment = Poseidon(destinationChainID, amount, pubKey, blinding)
-	nullifier = Poseidon(commitment, merklePath, sign(privKey, commitment, merklePath))
-
-	Commitments adhering to different hash functions and formats will invalidate
-	any attempt at withdrawal.
-	
-	Using the preimage / UTXO of the commitment, users can generate a zkSNARK proof that
-	the UTXO is located in one-of-many VAnchor merkle trees and that the commitment's
-	destination chain id matches the underlying chain id of the VAnchor where the
-	transaction is taking place. The chain id opcode is leveraged to prevent any
-	tampering of this data.
- */
+/// @title Variable Anchor contract
+/// @author Webb Technologies
+/// @notice The Variable Anchor is a variable-denominated shielded pool system
+/// derived from Tornado Nova (tornado-pool). This system extends the shielded
+/// pool system into a bridged system and allows for join/split transactions.
+///
+/// The system is built on top the VAnchorBase/AnchorBase/LinkableAnchor system which allows
+/// it to be linked to other VAnchor contracts through a simple graph-like
+/// interface where anchors maintain edges of their neighboring anchors.
+///
+/// The system requires users to create and deposit UTXOs for the supported ERC20
+/// asset into the smart contract and insert a commitment into the underlying
+/// merkle tree of the form: commitment = Poseidon(chainID, amount, pubKey, blinding).
+/// The hash input is the UTXO data. All deposits/withdrawals are unified under
+/// a common `transact` function which requires a zkSNARK proof that the UTXO commitments
+/// are well-formed (i.e. that the deposit amount matches the sum of new UTXOs' amounts).
+/// 
+/// Information regarding the commitments:
+/// - Poseidon is a zkSNARK friendly hash function
+/// - destinationChainID is the chainId of the destination chain, where the withdrawal
+///   is intended to be made
+/// - Details of the UTXO and hashes are below
+///
+/// UTXO = { destinationChainID, amount, pubkey, blinding }
+/// commitment = Poseidon(destinationChainID, amount, pubKey, blinding)
+/// nullifier = Poseidon(commitment, merklePath, sign(privKey, commitment, merklePath))
+///
+/// Commitments adhering to different hash functions and formats will invalidate
+/// any attempt at withdrawal.
+/// 
+/// Using the preimage / UTXO of the commitment, users can generate a zkSNARK proof that
+/// the UTXO is located in one-of-many VAnchor merkle trees and that the commitment's
+/// destination chain id matches the underlying chain id of the VAnchor where the
+/// transaction is taking place. The chain id opcode is leveraged to prevent any
+/// tampering of this data.
 abstract contract VAnchor is ZKVAnchorBase {
 	address public immutable token;
 

--- a/packages/contracts/contracts/vanchors/base/VAnchor.sol
+++ b/packages/contracts/contracts/vanchors/base/VAnchor.sol
@@ -25,7 +25,7 @@ import "../../libs/VAnchorEncodeInputs.sol";
 /// The hash input is the UTXO data. All deposits/withdrawals are unified under
 /// a common `transact` function which requires a zkSNARK proof that the UTXO commitments
 /// are well-formed (i.e. that the deposit amount matches the sum of new UTXOs' amounts).
-/// 
+///
 /// Information regarding the commitments:
 /// - Poseidon is a zkSNARK friendly hash function
 /// - destinationChainID is the chainId of the destination chain, where the withdrawal
@@ -38,7 +38,7 @@ import "../../libs/VAnchorEncodeInputs.sol";
 ///
 /// Commitments adhering to different hash functions and formats will invalidate
 /// any attempt at withdrawal.
-/// 
+///
 /// Using the preimage / UTXO of the commitment, users can generate a zkSNARK proof that
 /// the UTXO is located in one-of-many VAnchor merkle trees and that the commitment's
 /// destination chain id matches the underlying chain id of the VAnchor where the

--- a/packages/contracts/contracts/vanchors/base/VAnchorBase.sol
+++ b/packages/contracts/contracts/vanchors/base/VAnchorBase.sol
@@ -14,9 +14,9 @@ import "../../structs/PublicInputs.sol";
 import "../../interfaces/tokens/IMintableERC20.sol";
 import "../../interfaces/tokens/ITokenWrapper.sol";
 
-/** @dev This contract(pool) allows deposit of an arbitrary amount to it, shielded transfer to another registered user inside the pool
- * and withdrawal from the pool. Project utilizes UTXO model to handle users' funds.
- */
+/// @title VAnchorBase contract.
+/// @author Webb Technologies.
+/// @notice This contract is used to expose VAnchor API methods for insertion and parameter modifications.
 abstract contract VAnchorBase is LinkableAnchor {
 	using SafeERC20 for IERC20;
 
@@ -29,8 +29,7 @@ abstract contract VAnchorBase is LinkableAnchor {
 
 	struct Account {
 		address owner;
-		// A byte array which contains the public key from (0,64) and
-		// the encryption key from (64, 128)
+		/// A byte array which contains the public key from (0,64) and the encryption key from (64, 128)
 		bytes keyData;
 	}
 
@@ -43,12 +42,10 @@ abstract contract VAnchorBase is LinkableAnchor {
 	event NewNullifier(uint256 nullifier);
 	event PublicKey(address indexed owner, bytes key);
 
-	/**
-		@dev The constructor
-		@param _levels The number of levels in the merkle tree
-		@param _handler handler address for the merkle tree
-		@param _maxEdges The maximum number of edges for the linked anchor
-	*/
+	/// @dev The constructor
+	/// @param _levels The number of levels in the merkle tree
+	/// @param _handler handler address for the merkle tree
+	/// @param _maxEdges The maximum number of edges for the linked anchor
 	constructor(
 		uint32 _levels,
 		address _handler,
@@ -102,12 +99,10 @@ abstract contract VAnchorBase is LinkableAnchor {
 		maximumDepositAmount = _maximumDepositAmount;
 	}
 
-	/**
-        @notice Inserts a commitment into the tree
-        @notice This is an internal function and meant to be used by a child contract.
-        @param _commitment The note commitment = Poseidon(chainId, nullifier, secret)
-        @return uint32 The index of the inserted commitment
-    */
+	/// @notice Inserts a commitment into the tree
+	/// @notice This is an internal function and meant to be used by a child contract.
+	/// @param _commitment The note commitment = Poseidon(chainId, nullifier, secret)
+	/// @return uint32 The index of the inserted commitment
 	function insert(uint256 _commitment) internal returns (uint32) {
 		require(!commitments[_commitment], "The commitment has been submitted");
 
@@ -118,14 +113,12 @@ abstract contract VAnchorBase is LinkableAnchor {
 		return insertedIndex;
 	}
 
-	/**
-        @notice Inserts two commitments into the tree. Useful for contracts
-        that need to insert two commitments at once.
-        @notice This is an internal function and meant to be used by a child contract.
-        @param _firstCommitment The first note commitment
-        @param _secondCommitment The second note commitment
-        @return uint32 The index of the first inserted commitment
-     */
+	/// @notice Inserts two commitments into the tree. Useful for contracts
+	/// that need to insert two commitments at once.
+	/// @notice This is an internal function and meant to be used by a child contract.
+	/// @param _firstCommitment The first note commitment
+	/// @param _secondCommitment The second note commitment
+	/// @return uint32 The index of the first inserted commitment
 	function insertTwo(
 		uint256 _firstCommitment,
 		uint256 _secondCommitment
@@ -142,12 +135,10 @@ abstract contract VAnchorBase is LinkableAnchor {
 		return insertedIndex;
 	}
 
-	/**
-		@notice Wraps a token for the `msg.sender`
-		@param _fromTokenAddress The address of the token to wrap from
-		@param _toTokenAddress The address of the token to wrap into
-		@param _extAmount The external amount for the transaction
-	 */
+	/// @notice Wraps a token for the `msg.sender`
+	/// @param _fromTokenAddress The address of the token to wrap from
+	/// @param _toTokenAddress The address of the token to wrap into
+	/// @param _extAmount The external amount for the transaction
 	function _executeWrapping(
 		address _fromTokenAddress,
 		address _toTokenAddress,
@@ -177,13 +168,11 @@ abstract contract VAnchorBase is LinkableAnchor {
 		return wrapAmount;
 	}
 
-	/**
-		@notice Unwraps into a valid token for the `msg.sender`
-		@param _fromTokenAddress The address of the token to unwrap from
-		@param _toTokenAddress The address of the token to unwrap into
-		@param _recipient The address of the recipient for the unwrapped assets
-		@param _minusExtAmount Negative external amount for the transaction
-	 */
+	/// @notice Unwraps into a valid token for the `msg.sender`
+	/// @param _fromTokenAddress The address of the token to unwrap from
+	/// @param _toTokenAddress The address of the token to unwrap into
+	/// @param _recipient The address of the recipient for the unwrapped assets
+	/// @param _minusExtAmount Negative external amount for the transaction
 	function _withdrawAndUnwrap(
 		address _fromTokenAddress,
 		address _toTokenAddress,
@@ -202,13 +191,11 @@ abstract contract VAnchorBase is LinkableAnchor {
 		);
 	}
 
-	/**
-		@notice Process the withdrawal by sending/minting the wrapped tokens to/for the recipient
-		@param _token The token to withdraw
-		@param _recipient The recipient of the tokens
-		@param _minusExtAmount The amount of tokens to withdraw. Since
-		withdrawal ext amount is negative we apply a minus sign once more.
-	 */
+	/// @notice Process the withdrawal by sending/minting the wrapped tokens to/for the recipient
+	/// @param _token The token to withdraw
+	/// @param _recipient The recipient of the tokens
+	/// @param _minusExtAmount The amount of tokens to withdraw. Since
+	/// withdrawal ext amount is negative we apply a minus sign once more.
 	function _processWithdraw(
 		address _token,
 		address _recipient,
@@ -224,12 +211,10 @@ abstract contract VAnchorBase is LinkableAnchor {
 		}
 	}
 
-	/**
-		@notice Process and pay the relayer their fee. Mint the fee if contract has no balance.
-		@param _token The token to pay the fee in
-		@param _relayer The relayer of the transaction
-		@param _fee The fee to pay
-	 */
+	/// @notice Process and pay the relayer their fee. Mint the fee if contract has no balance.
+	/// @param _token The token to pay the fee in
+	/// @param _relayer The relayer of the transaction
+	/// @param _fee The fee to pay
 	function _processFee(address _token, address _relayer, uint256 _fee) internal virtual {
 		uint balance = IERC20(_token).balanceOf(address(this));
 		if (_fee > 0) {
@@ -242,12 +227,10 @@ abstract contract VAnchorBase is LinkableAnchor {
 		}
 	}
 
-	/**
-		@notice Process the refund and send it to the recipient. checks if the msg.value is enough to cover the refund
-		@param _refund The refund amount in native token
-		@param _recipient The recipient of the refund
-		@param _relayer The relayer of the transaction
-	 */
+	/// @notice Process the refund and send it to the recipient. checks if the msg.value is enough to cover the refund
+	/// @param _refund The refund amount in native token
+	/// @param _recipient The recipient of the refund
+	/// @param _relayer The relayer of the transaction
 	function _processRefund(
 		uint256 _refund,
 		address _recipient,
@@ -262,20 +245,16 @@ abstract contract VAnchorBase is LinkableAnchor {
 		}
 	}
 
-	/**
-        @notice Whether a note is already spent
-        @param _nullifierHash The nullifier hash of the deposit note
-        @return bool Whether the note is already spent
-    */
+	/// @notice Whether a note is already spent
+	/// @param _nullifierHash The nullifier hash of the deposit note
+	/// @return bool Whether the note is already spent
 	function isSpent(uint256 _nullifierHash) public view returns (bool) {
 		return nullifierHashes[_nullifierHash];
 	}
 
-	/**
-        @notice Whether an array of notes is already spent
-        @param _nullifierHashes The array of nullifier hashes of the deposit notes
-        @return bool[] An array indicated whether each note's nullifier hash is already spent
-    */
+	/// @notice Whether an array of notes is already spent
+	/// @param _nullifierHashes The array of nullifier hashes of the deposit notes
+	/// @return bool[] An array indicated whether each note's nullifier hash is already spent
 	function isSpentArray(
 		uint256[] calldata _nullifierHashes
 	) external view returns (bool[] memory) {
@@ -289,12 +268,10 @@ abstract contract VAnchorBase is LinkableAnchor {
 		return spent;
 	}
 
-	/**
-        @notice Set a new handler with a nonce
-        @dev Can only be called by the `AnchorHandler` contract
-        @param _handler The new handler address
-        @param _nonce The nonce for updating the new handler
-     */
+	/// @notice Set a new handler with a nonce
+	/// @dev Can only be called by the `AnchorHandler` contract
+	/// @param _handler The new handler address
+	/// @param _nonce The nonce for updating the new handler
 	function setHandler(
 		address _handler,
 		uint32 _nonce

--- a/packages/contracts/contracts/vanchors/base/ZKVAnchorBase.sol
+++ b/packages/contracts/contracts/vanchors/base/ZKVAnchorBase.sol
@@ -9,26 +9,22 @@ import "./VAnchorBase.sol";
 import "../../interfaces/verifiers/ISetVerifier.sol";
 import "../../verifiers/TxProofVerifier.sol";
 
-/**
-	@title ZK VAnchor Base
-	@author Webb Technologies
-	@notice The base VAnchor contract for all VAnchors leveraging zero knowledge proofs.
-	This contract implements the most basic VAnchor for a single token. All other
-	contracts should inherit from this contract and override methods as needed.
- */
+/// @title ZK VAnchor Base
+/// @author Webb Technologies
+/// @notice The base VAnchor contract for all VAnchors leveraging zero knowledge proofs.
+/// This contract implements the most basic VAnchor for a single token. All other
+/// contracts should inherit from this contract and override methods as needed.
 abstract contract ZKVAnchorBase is VAnchorBase, TxProofVerifier, ISetVerifier {
 	using SafeERC20 for IERC20;
 
-	/**
-		@notice The VAnchor constructor
-		@param _verifier The address of SNARK verifier for this contract
-		@param _levels The height/# of levels of underlying Merkle Tree
-		@param _handler The address of AnchorHandler for this contract
-		@param _maxEdges The maximum number of edges in the LinkableAnchor + Verifier supports.
-		@notice The `_maxEdges` is zero-knowledge circuit dependent, meaning the
-		`_verifier` ONLY supports a certain maximum # of edges. Therefore we need to
-		limit the size of the LinkableAnchor with this parameter.
-	*/
+	/// @notice The VAnchor constructor
+	/// @param _verifier The address of SNARK verifier for this contract
+	/// @param _levels The height/# of levels of underlying Merkle Tree
+	/// @param _handler The address of AnchorHandler for this contract
+	/// @param _maxEdges The maximum number of edges in the LinkableAnchor + Verifier supports.
+	/// @notice The `_maxEdges` is zero-knowledge circuit dependent, meaning the
+	/// `_verifier` ONLY supports a certain maximum # of edges. Therefore we need to
+	/// limit the size of the LinkableAnchor with this parameter.
 	constructor(
 		IAnchorVerifier _verifier,
 		uint32 _levels,
@@ -36,14 +32,12 @@ abstract contract ZKVAnchorBase is VAnchorBase, TxProofVerifier, ISetVerifier {
 		uint8 _maxEdges
 	) VAnchorBase(_levels, _handler, _maxEdges) TxProofVerifier(_verifier) {}
 
-	/**
-		@notice Registers and transacts in a single flow
-		@param _proof The zkSNARK proof
-		@param _externalData The serialized external data
-		@param _auxPublicInputs The extension public inputs for the zkSNARK proof
-		@param _publicInputs The public inputs for the zkSNARK proof
-		@param _encryptions The encrypted outputs
-	 */
+	/// @notice Registers and transacts in a single flow
+	/// @param _proof The zkSNARK proof
+	/// @param _externalData The serialized external data
+	/// @param _auxPublicInputs The extension public inputs for the zkSNARK proof
+	/// @param _publicInputs The public inputs for the zkSNARK proof
+	/// @param _encryptions The encrypted outputs
 	function registerAndTransact(
 		Account memory _account,
 		bytes memory _proof,
@@ -56,14 +50,12 @@ abstract contract ZKVAnchorBase is VAnchorBase, TxProofVerifier, ISetVerifier {
 		transact(_proof, _auxPublicInputs, _externalData, _publicInputs, _encryptions);
 	}
 
-	/**
-		@notice Transacts in a single flow
-		@param _proof The zkSNARK proof
-		@param _externalData The serialized external data
-		@param _auxPublicInputs The extension public inputs for the zkSNARK proof
-		@param _publicInputs The public inputs for the zkSNARK proof
-		@param _encryptions The encrypted outputs
-	 */
+	/// @notice Transacts in a single flow
+	/// @param _proof The zkSNARK proof
+	/// @param _externalData The serialized external data
+	/// @param _auxPublicInputs The extension public inputs for the zkSNARK proof
+	/// @param _publicInputs The public inputs for the zkSNARK proof
+	/// @param _encryptions The encrypted outputs
 	function transact(
 		bytes memory _proof,
 		bytes memory _auxPublicInputs,
@@ -72,16 +64,14 @@ abstract contract ZKVAnchorBase is VAnchorBase, TxProofVerifier, ISetVerifier {
 		Encryptions memory _encryptions
 	) public payable virtual;
 
-	/**
-		@notice Executes a deposit/withdrawal or combination join/split transaction
-		including possible wrapping or unwrapping if a valid token is provided.
-		@param _wrappedToken The wrapped token address (only tokens living on the bridge)
-		@param _proof The zkSNARK proof
-		@param _externalData The serialized external data
-		@param _auxPublicInputs The extension public inputs for the zkSNARK proof
-		@param _publicInputs The public inputs for the zkSNARK proof
-		@param _encryptions The encrypted outputs
-	 */
+	/// @notice Executes a deposit/withdrawal or combination join/split transaction
+	/// including possible wrapping or unwrapping if a valid token is provided.
+	/// @param _wrappedToken The wrapped token address (only tokens living on the bridge)
+	/// @param _proof The zkSNARK proof
+	/// @param _externalData The serialized external data
+	/// @param _auxPublicInputs The extension public inputs for the zkSNARK proof
+	/// @param _publicInputs The public inputs for the zkSNARK proof
+	/// @param _encryptions The encrypted outputs
 	function _transact(
 		address _wrappedToken,
 		bytes memory _proof,
@@ -156,27 +146,23 @@ abstract contract ZKVAnchorBase is VAnchorBase, TxProofVerifier, ISetVerifier {
 		_executeInsertions(_publicInputs, _encryptions);
 	}
 
-	/**
-		@notice Inserts the output commitments into the underlying merkle system
-		@param _publicInputs The public inputs for the proof
-		@param _encryptions The encryptions of the output commitments
-	 */
+	/// @notice Inserts the output commitments into the underlying merkle system
+	/// @param _publicInputs The public inputs for the proof
+	/// @param _encryptions The encryptions of the output commitments
 	function _executeInsertions(
 		PublicInputs memory _publicInputs,
 		Encryptions memory _encryptions
 	) internal virtual;
 
-	/**
-		@notice Checks whether the transaction is valid
-		1. Checks that the nullifiers are not spent
-		2. Checks that the public amount is valid (doesn't exceed the MAX_FEE or MAX_EXT_AMOUNT and doesn't overflow)
-		3. Checks that the zkSNARK proof verifies
-		@param _proof The zkSNARK proof
-		@param _externalData The serialized external data
-		@param _auxPublicInputs The extension public inputs for the zkSNARK proof
-		@param _publicInputs The public inputs for the zkSNARK proof
-		@param _encryptions The encrypted outputs
-	 */
+	/// @notice Checks whether the transaction is valid
+	///	1. Checks that the nullifiers are not spent
+	///	2. Checks that the public amount is valid (doesn't exceed the MAX_FEE or MAX_EXT_AMOUNT and doesn't overflow)
+	///	3. Checks that the zkSNARK proof verifies
+	/// @param _proof The zkSNARK proof
+	/// @param _externalData The serialized external data
+	/// @param _auxPublicInputs The extension public inputs for the zkSNARK proof
+	/// @param _publicInputs The public inputs for the zkSNARK proof
+	/// @param _encryptions The encrypted outputs
 	function _executeValidationAndVerification(
 		bytes memory _proof,
 		bytes memory _auxPublicInputs,
@@ -206,13 +192,11 @@ abstract contract ZKVAnchorBase is VAnchorBase, TxProofVerifier, ISetVerifier {
 		}
 	}
 
-	/**
-		@notice Verifies the zero-knowledge proof and validity of roots/public inputs.
-		@param _proof The zkSNARK proof
-		@param _auxPublicInputs The extension public inputs for the zkSNARK proof
-		@param _publicInputs The public inputs for the zkSNARK proof
-		@param _encryptions The encrypted outputs
-	 */
+	/// @notice Verifies the zero-knowledge proof and validity of roots/public inputs.
+	/// @param _proof The zkSNARK proof
+	/// @param _auxPublicInputs The extension public inputs for the zkSNARK proof
+	/// @param _publicInputs The public inputs for the zkSNARK proof
+	/// @param _encryptions The encrypted outputs
 	function _executeVerification(
 		bytes memory _proof,
 		bytes memory _auxPublicInputs,
@@ -226,12 +210,10 @@ abstract contract ZKVAnchorBase is VAnchorBase, TxProofVerifier, ISetVerifier {
 		Encryptions memory _encryptions
 	) public virtual returns (bytes32);
 
-	/**
-		@notice Set a new verifier with a nonce
-		@dev Can only be called by the `AnchorHandler` contract
-		@param _verifier The new verifier address
-		@param _nonce The nonce for updating the new verifier
-	 */
+	/// @notice Set a new verifier with a nonce
+	/// @dev Can only be called by the `AnchorHandler` contract
+	/// @param _verifier The new verifier address
+	/// @param _nonce The nonce for updating the new verifier
 	function setVerifier(
 		address _verifier,
 		uint32 _nonce

--- a/packages/contracts/contracts/vanchors/extensions/ChainalysisVAnchor.sol
+++ b/packages/contracts/contracts/vanchors/extensions/ChainalysisVAnchor.sol
@@ -8,11 +8,9 @@ pragma solidity ^0.8.18;
 import "../instances/VAnchorTree.sol";
 import "../../utils/SanctionFilter.sol";
 
-/**
-	@title Chainalysis Variable Anchor contract
-	@author Webb Technologies
-	@notice The main addition here is a filter for sanctioned addresses on transactions.
- */
+/// @title Chainalysis Variable Anchor contract
+/// @author Webb Technologies
+/// @notice The main addition here is a filter for sanctioned addresses on transactions.
 contract ChainalysisVAnchor is VAnchorTree, SanctionFilter {
 	using SafeERC20 for IERC20;
 

--- a/packages/contracts/contracts/vanchors/extensions/RateLimitedVAnchor.sol
+++ b/packages/contracts/contracts/vanchors/extensions/RateLimitedVAnchor.sol
@@ -7,13 +7,11 @@ pragma solidity ^0.8.18;
 
 import "../instances/VAnchorTree.sol";
 
-/**
-	@title Rate Limited Variable Anchor contract
-	@author Webb Technologies
-	@notice The main addition here is a rate limiter on the amount that can be withdrawn
-	in a single day. This is to prevent a single user from withdrawing all of the funds
-	in the pool in a single day.
- */
+/// @title Rate Limited Variable Anchor contract
+/// @author Webb Technologies
+/// @notice The main addition here is a rate limiter on the amount that can be withdrawn
+/// in a single day. This is to prevent a single user from withdrawing all of the funds
+/// in the pool in a single day.
 contract RateLimitedVAnchor is VAnchorTree {
 	using SafeERC20 for IERC20;
 

--- a/packages/contracts/contracts/vanchors/instances/VAnchorForest.sol
+++ b/packages/contracts/contracts/vanchors/instances/VAnchorForest.sol
@@ -8,28 +8,24 @@ pragma solidity ^0.8.18;
 import "../base/VAnchor.sol";
 import "../../trees/MerkleForest.sol";
 
-/**
-	@title Variable Anchor Forest contract
-	@author Webb Technologies
-	@notice The Variable Anchor Forest is the same as a VAnchor system but with
-	many merkle trees for commitment storage.
- */
+/// @title Variable Anchor Forest contract
+/// @author Webb Technologies
+/// @notice The Variable Anchor Forest is the same as a VAnchor system but with
+/// many merkle trees for commitment storage.
 contract VAnchorForest is VAnchor, MerkleForest {
 	using SafeERC20 for IERC20;
 
-	/**
-		@notice The VAnchor Forest constructor
-		@param _verifier The address of SNARK verifier for this contract
-		@param _forestLevels The height/# of levels of underlying Merkle Forest
-		@param _subtreeLevels The height/# of levels of underlying Merkle Trees in the forest
-		@param _hasher The address of hash contract
-		@param _handler The address of AnchorHandler for this contract
-		@param _token The address of the token that is used to pay the deposit
-		@param _maxEdges The maximum number of edges in the LinkableAnchor + Verifier supports.
-		@notice The `_maxEdges` is zero-knowledge circuit dependent, meaning the
-		`_verifier` ONLY supports a certain maximum # of edges. Therefore we need to
-		limit the size of the LinkableAnchor with this parameter.
-	*/
+	/// @notice The VAnchor Forest constructor
+	/// @param _verifier The address of SNARK verifier for this contract
+	/// @param _forestLevels The height/# of levels of underlying Merkle Forest
+	/// @param _subtreeLevels The height/# of levels of underlying Merkle Trees in the forest
+	/// @param _hasher The address of hash contract
+	/// @param _handler The address of AnchorHandler for this contract
+	/// @param _token The address of the token that is used to pay the deposit
+	/// @param _maxEdges The maximum number of edges in the LinkableAnchor + Verifier supports.
+	/// @notice The `_maxEdges` is zero-knowledge circuit dependent, meaning the
+	/// `_verifier` ONLY supports a certain maximum # of edges. Therefore we need to
+	/// limit the size of the LinkableAnchor with this parameter.
 	constructor(
 		IAnchorVerifier _verifier,
 		uint32 _forestLevels,

--- a/packages/contracts/contracts/vanchors/instances/VAnchorTree.sol
+++ b/packages/contracts/contracts/vanchors/instances/VAnchorTree.sol
@@ -8,27 +8,23 @@ pragma solidity ^0.8.18;
 import "../base/VAnchor.sol";
 import "../../trees/MerkleTree.sol";
 
-/**
-	@title Variable Anchor Forest contract
-	@author Webb Technologies
-	@notice The Variable Anchor Forest is the same as a VAnchor system but with
-	many merkle trees for commitment storage.
- */
+/// @title Variable Anchor Forest contract
+/// @author Webb Technologies
+/// @notice The Variable Anchor Forest is the same as a VAnchor system but with
+/// many merkle trees for commitment storage.
 contract VAnchorTree is VAnchor, MerkleTree {
 	using SafeERC20 for IERC20;
 
-	/**
-		@notice The VAnchorTree constructor
-		@param _verifier The address of SNARK verifier for this contract
-		@param _merkleTreeLevels The height/# of levels of underlying Merkle Tree
-		@param _hasher The address of hash contract
-		@param _handler The address of AnchorHandler for this contract
-		@param _token The address of the token that is used to pay the deposit
-		@param _maxEdges The maximum number of edges in the LinkableAnchor + Verifier supports.
-		@notice The `_maxEdges` is zero-knowledge circuit dependent, meaning the
-		`_verifier` ONLY supports a certain maximum # of edges. Therefore we need to
-		limit the size of the LinkableAnchor with this parameter.
-	*/
+	/// @notice The VAnchorTree constructor
+	/// @param _verifier The address of SNARK verifier for this contract
+	/// @param _merkleTreeLevels The height/# of levels of underlying Merkle Tree
+	/// @param _hasher The address of hash contract
+	/// @param _handler The address of AnchorHandler for this contract
+	/// @param _token The address of the token that is used to pay the deposit
+	/// @param _maxEdges The maximum number of edges in the LinkableAnchor + Verifier supports.
+	/// @notice The `_maxEdges` is zero-knowledge circuit dependent, meaning the
+	/// `_verifier` ONLY supports a certain maximum # of edges. Therefore we need to
+	/// limit the size of the LinkableAnchor with this parameter.
 	constructor(
 		IAnchorVerifier _verifier,
 		uint32 _merkleTreeLevels,

--- a/packages/contracts/contracts/verifiers/TxProofVerifier.sol
+++ b/packages/contracts/contracts/verifiers/TxProofVerifier.sol
@@ -8,6 +8,8 @@ import "../utils/ProofUtils.sol";
 
 pragma solidity ^0.8.18;
 
+/// @title TxProofVerifier contract.
+/// @notice This contract is used to verify the zero knowledge proofs.
 contract TxProofVerifier is ProofUtils {
 	IAnchorVerifier public verifier;
 
@@ -15,14 +17,12 @@ contract TxProofVerifier is ProofUtils {
 		verifier = _verifier;
 	}
 
-	/**
-        @notice Verifies a zero-knowledge proof of knowledge over the tree according
-        to the underlying `Verifier` circuit this `AnchorBase` is using.
-        @notice This aims to be as generic as currently needed to support our VAnchor (variable deposit) contracts.
-        @param _proof The zero-knowledge proof bytes
-        @param _input The public input packed bytes
-        @return bool Whether the proof is valid
-     */
+	/// @notice Verifies a zero-knowledge proof of knowledge over the tree according
+	/// to the underlying `Verifier` circuit this `AnchorBase` is using.
+	/// @notice This aims to be as generic as currently needed to support our VAnchor (variable deposit) contracts.
+	/// @param _proof The zero-knowledge proof bytes
+	/// @param _input The public input packed bytes
+	/// @return bool Whether the proof is valid
 	function verify(
 		bytes memory _proof,
 		bytes memory _input,

--- a/packages/contracts/contracts/verifiers/VAnchorVerifier.sol
+++ b/packages/contracts/contracts/verifiers/VAnchorVerifier.sol
@@ -8,6 +8,9 @@ pragma solidity ^0.8.18;
 import "../interfaces/verifiers/IAnchorVerifier.sol";
 import "../interfaces/verifiers/IVAnchorVerifier.sol";
 
+/// @title VAnchorVerifier contract.
+/// @author Webb Technologies.
+/// @notice This contract is used to verify the proofs for the VAnchor.
 contract VAnchorVerifier is IAnchorVerifier {
 	IVAnchorVerifier2_2 public v2_2;
 	IVAnchorVerifier2_16 public v2_16;

--- a/packages/contracts/test/governance/governable.test.ts
+++ b/packages/contracts/test/governance/governable.test.ts
@@ -14,7 +14,7 @@ const TruffleAssert = require('truffle-assertions');
 import { Governable, Governable__factory } from '@webb-tools/contracts';
 import { ethers } from 'ethers';
 
-describe.only('Governable Contract', () => {
+describe('Governable Contract', () => {
   let governableInstance: Governable;
   let sender: ethers.Signer;
   let nextGovernor: ethers.Signer;
@@ -56,7 +56,7 @@ describe.only('Governable Contract', () => {
     );
   });
 
-  it.only('should check ownership is transferred to new governor via signed public key', async () => {
+  it('should check ownership is transferred to new governor via signed public key', async () => {
     const wallet = ethers.Wallet.createRandom();
     const key = ec.keyFromPrivate(wallet.privateKey.slice(2), 'hex');
     const pubkey = key.getPublic().encode('hex').slice(2);

--- a/packages/contracts/test/governance/governable.test.ts
+++ b/packages/contracts/test/governance/governable.test.ts
@@ -14,7 +14,7 @@ const TruffleAssert = require('truffle-assertions');
 import { Governable, Governable__factory } from '@webb-tools/contracts';
 import { ethers } from 'ethers';
 
-describe('Governable Contract', () => {
+describe.only('Governable Contract', () => {
   let governableInstance: Governable;
   let sender: ethers.Signer;
   let nextGovernor: ethers.Signer;
@@ -28,7 +28,7 @@ describe('Governable Contract', () => {
     arbSigner = signers[2];
     // create poseidon hasher
     const govFactory = new Governable__factory(wallet);
-    governableInstance = await govFactory.deploy(sender.address, 0);
+    governableInstance = await govFactory.deploy(sender.address, 0, 0);
     await governableInstance.deployed();
   });
 
@@ -56,14 +56,16 @@ describe('Governable Contract', () => {
     );
   });
 
-  it('should check ownership is transferred to new governor via signed public key', async () => {
+  it.only('should check ownership is transferred to new governor via signed public key', async () => {
     const wallet = ethers.Wallet.createRandom();
     const key = ec.keyFromPrivate(wallet.privateKey.slice(2), 'hex');
     const pubkey = key.getPublic().encode('hex').slice(2);
+    console.log(pubkey);
     const publicKey = '0x' + pubkey;
     let nextGovernorAddress = ethers.utils.getAddress(
       '0x' + ethers.utils.keccak256(publicKey).slice(-40)
     );
+    console.log(nextGovernorAddress);
     let firstRotationKey = nextGovernorAddress;
     await governableInstance.transferOwnership(nextGovernorAddress, 1);
     assert.strictEqual(await governableInstance.governor(), nextGovernorAddress);
@@ -275,11 +277,6 @@ describe('Governable Contract', () => {
     assert.notEqual(
       await governableInstance.governor(),
       '0x1111111111111111111111111111111111111111'
-    );
-
-    await TruffleAssert.reverts(
-      governableInstance.connect(proposer0Signer).voteInFavorForceSetGovernor(voteProposer0),
-      'already voted'
     );
 
     const voteProposer1 = {

--- a/packages/contracts/test/trees/MerkleTreePoseidon.test.ts
+++ b/packages/contracts/test/trees/MerkleTreePoseidon.test.ts
@@ -11,7 +11,7 @@ import { PoseidonHasher } from '@webb-tools/anchors';
 const TruffleAssert = require('truffle-assertions');
 const assert = require('assert');
 
-const MerkleTreeWithHistory = artifacts.require('MerkleTreePoseidonMock');
+const MerkleTreeWithHistory = artifacts.require('MerkleTreeMock');
 
 contract('MerkleTree w/ Poseidon hasher', (accounts) => {
   let merkleTreeWithHistory;


### PR DESCRIPTION
Changes
- For all contracts, use tabs over spaces
- For all contracts, use `///` for contract/function documentation
- For governable, support submission of votes with signatures in addition to direct tx.
- For governable, implement Forge tests
- For governable, modify Vote struct ordering so we can reliably encode it on Tangle.