### PR TITLE
Add manual gas limits to Signature Bridge calls

### DIFF
--- a/packages/vbridge/src/VBridge.ts
+++ b/packages/vbridge/src/VBridge.ts
@@ -203,7 +203,7 @@ export class VBridge<A extends BaseContract> {
         tokenInstance = vBridgeInput.webbTokens.get(chainId)!;
       }
 
-      await vBridgeInstance.setTokenWrapperHandler(tokenWrapperHandler);
+      vBridgeInstance.setTokenWrapperHandler(tokenWrapperHandler);
       await vBridgeInstance.setFungibleTokenResourceWithSignature(tokenInstance);
 
       // Add all token addresses to the governed token instance.


### PR DESCRIPTION
This is mainly to address tangle EVM `estimateGas` problem.

Part of https://github.com/webb-tools/tangle/issues/243