### PR TITLE
Upgrade snarkjs & Modularize Export in `@webb-tools/utils` Package

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,7 @@
     "packages/*",
     "examples/*"
   ],
+  "useWorkspaces": true,
   "version": "independent",
   "npmClient": "yarn"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,6 @@
     "packages/*",
     "examples/*"
   ],
-  "useWorkspaces": true,
   "version": "independent",
   "npmClient": "yarn"
 }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "nx": "^15.9.2",
     "prettier-plugin-solidity": "^1.1.3",
     "rimraf": "^5.0.0",
-    "snarkjs": "^0.6.10",
+    "snarkjs": "^0.7.2",
     "solidity-coverage": "^0.8.2",
     "tomlify-j0.4": "^3.0.0",
     "truffle-assertions": "^0.9.2",

--- a/packages/anchors/package.json
+++ b/packages/anchors/package.json
@@ -19,7 +19,7 @@
     "circomlibjs": "^0.0.8",
     "ethers": "5.7.0",
     "jssha": "^3.2.0",
-    "snarkjs": "^0.6.10"
+    "snarkjs": "^0.7.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -15,7 +15,7 @@
     "circomlibjs": "^0.0.8",
     "elliptic": "6.5.4",
     "ethers": "5.7.0",
-    "snarkjs": "^0.6.10"
+    "snarkjs": "^0.7.2"
   },
   "publishConfig": {
     "access": "public"
@@ -30,5 +30,37 @@
   "devDependencies": {
     "@webb-tools/sdk-core": "0.1.4-126",
     "chai": "^4.3.7"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./bytes": {
+      "types": "./dist/bytes/index.d.ts",
+      "require": "./dist/bytes/index.js",
+      "default": "./dist/bytes/index.js"
+    },
+    "./proof": {
+      "types": "./dist/proof/index.d.ts",
+      "require": "./dist/proof/index.js",
+      "default": "./dist/proof/index.js"
+    },
+    "./protocol": {
+      "types": "./dist/protocol/index.d.ts",
+      "require": "./dist/protocol/index.js",
+      "default": "./dist/protocol/index.js"
+    },
+    "./fixtures": {
+      "types": "./dist/fixtures.d.ts",
+      "require": "./dist/fixtures.js",
+      "default": "./dist/fixtures.js"
+    },
+    "./utils": {
+      "types": "./dist/utils.d.ts",
+      "require": "./dist/utils.js",
+      "default": "./dist/utils.js"
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5736,6 +5736,13 @@ circom_runtime@0.1.22:
   dependencies:
     ffjavascript "0.2.57"
 
+circom_runtime@0.1.24:
+  version "0.1.24"
+  resolved "https://registry.yarnpkg.com/circom_runtime/-/circom_runtime-0.1.24.tgz#60ca8a31c3675802fbab5a0bcdeb02556e510733"
+  integrity sha512-H7/7I2J/cBmRnZm9docOCGhfxzS61BEm4TMCWcrZGsWNBQhePNfQq88Oj2XpUfzmBTCd8pRvRb3Mvazt3TMrJw==
+  dependencies:
+    ffjavascript "0.2.60"
+
 circomlib@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/circomlib/-/circomlib-2.0.5.tgz#183c703e53ed7d011811842dbeeeb9819f4cc1d6"
@@ -7975,6 +7982,24 @@ ffjavascript@0.2.57:
   dependencies:
     wasmbuilder "0.0.16"
     wasmcurves "0.2.0"
+    web-worker "^1.2.0"
+
+ffjavascript@0.2.60:
+  version "0.2.60"
+  resolved "https://registry.yarnpkg.com/ffjavascript/-/ffjavascript-0.2.60.tgz#4d8ae613d6bf4e98b3cc29ba10c626f5853854cf"
+  integrity sha512-T/9bnEL5xAZRDbQoEMf+pM9nrhK+C3JyZNmqiWub26EQorW7Jt+jR54gpqDhceA4Nj0YctPQwYnl8xa52/A26A==
+  dependencies:
+    wasmbuilder "0.0.16"
+    wasmcurves "0.2.2"
+    web-worker "^1.2.0"
+
+ffjavascript@0.2.62:
+  version "0.2.62"
+  resolved "https://registry.yarnpkg.com/ffjavascript/-/ffjavascript-0.2.62.tgz#f508dfe662a70181598ec5eb8ce5127eb342f624"
+  integrity sha512-uJ7MTrdzhX/3f+hxn0XhdXbJCqYZJSBB6y2/ui4t21vKYVjyTMlU80pPXu40ir6qpqbrdzUeKdlOdJ0aFG9UNA==
+  dependencies:
+    wasmbuilder "0.0.16"
+    wasmcurves "0.2.2"
     web-worker "^1.2.0"
 
 ffjavascript@^0.2.38, ffjavascript@^0.2.48, ffjavascript@^0.2.57:
@@ -13079,6 +13104,16 @@ r1csfile@0.0.45:
     fastfile "0.0.20"
     ffjavascript "0.2.57"
 
+r1csfile@0.0.47:
+  version "0.0.47"
+  resolved "https://registry.yarnpkg.com/r1csfile/-/r1csfile-0.0.47.tgz#ed95a0dc8e910e9c070253906f7a31bd8c5333c8"
+  integrity sha512-oI4mAwuh1WwuFg95eJDNDDL8hCaZkwnPuNZrQdLBWvDoRU7EG+L/MOHL7SwPW2Y+ZuYcTLpj3rBkgllBQZN/JA==
+  dependencies:
+    "@iden3/bigarray" "0.0.2"
+    "@iden3/binfileutils" "0.0.11"
+    fastfile "0.0.20"
+    ffjavascript "0.2.60"
+
 randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -14147,6 +14182,22 @@ snarkjs@^0.6.10:
     js-sha3 "^0.8.0"
     logplease "^1.2.15"
     r1csfile "0.0.45"
+
+snarkjs@^0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/snarkjs/-/snarkjs-0.7.2.tgz#ab719b065fcd9867d9ea14bed92f3acdca3c766f"
+  integrity sha512-A8yPFm9pRnZ7XYXfPSjSFnugEV1rsHGjb8W7c0Qk7nzXl5h3WANTkpVC5FYxakmw/GKWekz7wjjHaOFtPp823Q==
+  dependencies:
+    "@iden3/binfileutils" "0.0.11"
+    bfj "^7.0.2"
+    blake2b-wasm "^2.4.0"
+    circom_runtime "0.1.24"
+    ejs "^3.1.6"
+    fastfile "0.0.20"
+    ffjavascript "0.2.62"
+    js-sha3 "^0.8.0"
+    logplease "^1.2.15"
+    r1csfile "0.0.47"
 
 sockjs@^0.3.24:
   version "0.3.24"
@@ -15658,6 +15709,13 @@ wasmcurves@0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/wasmcurves/-/wasmcurves-0.2.1.tgz#416d15432a9c6a7b79ef6000eab1e8e7302624ad"
   integrity sha512-9ciO7bUE5bgpbOcdK7IO3enrSVIKHwrQmPibok4GLJWaCA7Wyqc9PRYnu5HbiFv9NDFNqVKPtU5R6Is5KujBLg==
+  dependencies:
+    wasmbuilder "0.0.16"
+
+wasmcurves@0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/wasmcurves/-/wasmcurves-0.2.2.tgz#ca444f6a6f6e2a5cbe6629d98ff478a62b4ccb2b"
+  integrity sha512-JRY908NkmKjFl4ytnTu5ED6AwPD+8VJ9oc94kdq7h5bIwbj0L4TDJ69mG+2aLs2SoCmGfqIesMWTEJjtYsoQXQ==
   dependencies:
     wasmbuilder "0.0.16"
 


### PR DESCRIPTION
### Summary of changes

- Upgraded snarkjs to its latest version to address the issue specified in https://github.com/webb-tools/webb.js/pull/320.
- Optimized the export of submodules in the `@webb-tools/utils` package, facilitating selective import of functions as needed by the client, thus eliminating the necessity to import the entire package.